### PR TITLE
Allow setting JSON-RPC providers via env. vars.

### DIFF
--- a/crates/oracle/config/test/indexed_chain_provider_via_env_var.toml
+++ b/crates/oracle/config/test/indexed_chain_provider_via_env_var.toml
@@ -1,0 +1,12 @@
+owner_address = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+contract_address = "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab"
+
+protocol_chain_polling_interval_in_seconds = 5
+epoch_duration = 2
+
+[protocol_chain]
+name = "eip155:1"
+jrpc = "http://127.0.0.1:8545/"
+
+[indexed_chains]
+"eip155:77" = "FOOBAR_EIP155:77"

--- a/crates/oracle/config/test/invalid_jrpc_provider_url.toml
+++ b/crates/oracle/config/test/invalid_jrpc_provider_url.toml
@@ -1,0 +1,15 @@
+# Hardhat's first account.
+owner_address = "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1"
+# Deployed in the first block.
+contract_address = "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab"
+
+protocol_chain_polling_interval_in_seconds = 5
+epoch_duration = 2
+
+[protocol_chain]
+name = "eip155:1"               # the CAIP2 network identifier for this chain
+jrpc = "http://127.0.0.1:8545/" # The URL to the JSON RPC for this network. Using Ganache in this example.
+
+[indexed_chains]
+"eip155:77" = "foobar"                               # POA Network Sokol
+"eip155:99" = "https://core-archive.blockscout.com/" # POA Network Core

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -1,4 +1,5 @@
 use crate::models::Caip2ChainId;
+use anyhow::Context;
 use clap::Parser;
 use secp256k1::SecretKey;
 use serde::Deserialize;
@@ -51,34 +52,65 @@ pub struct ProtocolChain {
 impl Config {
     /// Loads all configuration options from CLI arguments, the TOML
     /// configuration file, and environment variables.
-    ///
-    /// # Panics
-    ///
-    /// Will panic if any configuration value can't be read for any reason.
     pub fn parse() -> Self {
         let clap = Clap::parse();
-        let config_file =
-            ConfigFile::from_file(&clap.config_file).expect("Failed to read config file.");
+        let config_file = ConfigFile::from_file(&clap.config_file)
+            .context("Failed to read config file as valid TOML")
+            .unwrap();
 
+        Self::from_clap_and_config_file(clap, config_file)
+    }
+
+    #[cfg(test)]
+    fn parse_from(args: &[&str]) -> Self {
+        let clap = Clap::parse_from(args);
+        println!("clap config is {:?}", clap.config_file);
+        let config_file = ConfigFile::from_file(&clap.config_file).unwrap();
+
+        Self::from_clap_and_config_file(clap, config_file)
+    }
+
+    fn from_clap_and_config_file(clap: Clap, config_file: ConfigFile) -> Self {
         let retry_strategy_max_wait_time =
             Duration::from_secs(config_file.web3_transport_retry_max_wait_time_in_seconds);
 
         Self {
             log_level: clap.log_level,
-            owner_address: config_file.owner_address.parse().unwrap(),
-            owner_private_key: SecretKey::from_str(clap.owner_private_key.as_str()).unwrap(),
-            contract_address: config_file.contract_address.parse().unwrap(),
+            owner_address: config_file
+                .owner_address
+                .parse()
+                .context("Bad owner address")
+                .unwrap(),
+            owner_private_key: SecretKey::from_str(clap.owner_private_key.as_str())
+                .context("Bad private key")
+                .unwrap(),
+            contract_address: config_file
+                .contract_address
+                .parse()
+                .context("Bad contract address")
+                .unwrap(),
             subgraph_url: clap.subgraph_url,
             epoch_duration: config_file.epoch_duration,
             retry_strategy_max_wait_time,
             indexed_chains: config_file
                 .indexed_chains
                 .into_iter()
-                .map(|(chain_id, url)| IndexedChain {
-                    id: chain_id,
-                    jrpc_url: url,
+                .map(|(chain_id, provider)| {
+                    if let Ok(url) = Url::parse(provider.as_str()) {
+                        Ok(IndexedChain {
+                            id: chain_id,
+                            jrpc_url: url,
+                        })
+                    } else {
+                        let jrpc_url = std::env::var(provider)?;
+                        Ok(IndexedChain {
+                            id: chain_id,
+                            jrpc_url: Url::parse(jrpc_url.as_str()).unwrap(),
+                        })
+                    }
                 })
-                .collect(),
+                .collect::<anyhow::Result<Vec<IndexedChain>>>()
+                .unwrap(),
             protocol_chain: ProtocolChain {
                 id: config_file.protocol_chain.name,
                 jrpc_url: config_file.protocol_chain.jrpc,
@@ -105,7 +137,7 @@ struct Clap {
     #[clap(long)]
     subgraph_url: Url,
     /// The filepath of the TOML JSON-RPC configuration file.
-    #[clap(long, default_value = "config.toml", parse(from_os_str))]
+    #[clap(long, parse(from_os_str))]
     config_file: PathBuf,
 }
 
@@ -115,7 +147,7 @@ struct Clap {
 struct ConfigFile {
     owner_address: String,
     contract_address: String,
-    indexed_chains: HashMap<Caip2ChainId, Url>,
+    indexed_chains: HashMap<Caip2ChainId, String>,
     protocol_chain: SerdeProtocolChain,
     #[serde(default = "serde_defaults::epoch_duration")]
     epoch_duration: u64,
@@ -171,10 +203,59 @@ struct SerdeProtocolChain {
 mod tests {
     use super::*;
 
-    const SAMPLE_CONFIG: &str = include_str!("../config/dev/config.toml");
+    fn indexed_chain(config: &Config, id: &str) -> IndexedChain {
+        config
+            .indexed_chains
+            .iter()
+            .find(|x| x.id.as_str() == id)
+            .unwrap()
+            .clone()
+    }
+
+    fn config_file_flag(filename: &str) -> String {
+        format!(
+            "--config-file={}/config/{}",
+            env!("CARGO_MANIFEST_DIR"),
+            filename
+        )
+    }
 
     #[test]
-    fn deserialize_protocol_chain() {
-        toml::de::from_str::<ConfigFile>(SAMPLE_CONFIG).unwrap();
+    #[should_panic]
+    fn invalid_jrpc_provider_url() {
+        Config::parse_from(&[
+            "",
+            "--subgraph-url=https://example.com",
+            "--owner-private-key=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d",
+            config_file_flag("test/invalid_jrpc_provider_url.toml").as_str(),
+        ]);
+    }
+
+    #[test]
+    fn example_config() {
+        Config::parse_from(&[
+            "",
+            "--subgraph-url=https://example.com",
+            "--owner-private-key=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d",
+            config_file_flag("dev/config.toml").as_str(),
+        ]);
+    }
+
+    #[test]
+    fn set_jrpc_provider_via_env_var() {
+        let jrpc_url = "https://sokol-archive.blockscout.com/";
+        std::env::set_var("FOOBAR_EIP155:77", jrpc_url);
+
+        let config = Config::parse_from(&[
+            "",
+            "--subgraph-url=https://example.com",
+            "--owner-private-key=4f3edf983ac636a65a842ce7c78d9aa706d3b113bce9c46f30d7d21715b23b1d",
+            config_file_flag("test/indexed_chain_provider_via_env_var.toml").as_str(),
+        ]);
+
+        assert_eq!(
+            indexed_chain(&config, "eip155:77").jrpc_url.as_str(),
+            jrpc_url
+        );
     }
 }


### PR DESCRIPTION
The current problem we have is that users are required to submit a TOML configuration file which might contain sensitive information. Getting this sort of data from environment variables would be much better. This is the approach we're taking:

When a configuration file lists an invalid URL as a provider, the oracle will automatically try to read the environment variable with such name and parse that as a URL. E.g.:

```toml
[indexed_chains]
"eip155:77" = "JRC_PROVIDER_EIP155_77"
"eip155:99" = "https://example.com"
```

Possible future improvements:
- Use custom, `serde`-compatible types to achieve this result, rather than having to explicitly call a helper function.
- More testing.