### PR TITLE
Attempt `cargo-chef` caching on Debian

### DIFF
--- a/k8s/Dockerfile
+++ b/k8s/Dockerfile
@@ -1,29 +1,22 @@
 # https://www.lpalmieri.com/posts/fast-rust-docker-builds/
 
-ARG CARGO_CHEF_VERSION=0.1.37
-
-FROM rust:alpine AS cargo-chef
+FROM lukemathwalker/cargo-chef:latest AS cargo-chef-planner
 WORKDIR /app
-ARG CARGO_CHEF_VERSION
 
-RUN apk add --no-cache musl-dev && \
-	cargo install cargo-chef --locked --version $CARGO_CHEF_VERSION
 COPY . .
-
 # First, we use `cargo-chef` to compile a recipe of our Rust dependencies.
 RUN cargo chef prepare --recipe-path recipe.json
 
 
-FROM rust:alpine as builder
+FROM lukemathwalker/cargo-chef:latest as builder
 WORKDIR /app
-ARG CARGO_CHEF_VERSION
 
-RUN apk add --no-cache pkgconfig openssl-dev musl-dev && \
-	cargo install cargo-chef --locked --version $CARGO_CHEF_VERSION
+RUN apt-get install -y && \
+	apt-get install -y libc-dev pkg-config libssl-dev
 
 # Compile all Rust dependencies from `cargo-chef`. As long as
 # `cargo-chef-recipe.json` doesn't change, this will be cached.
-COPY --from=cargo-chef /app/recipe.json cargo-chef-recipe.json
+COPY --from=cargo-chef-planner /app/recipe.json cargo-chef-recipe.json
 RUN cargo chef cook --release --recipe-path cargo-chef-recipe.json
 
 # Finally, compile our binary in release mode.
@@ -31,10 +24,12 @@ COPY . .
 RUN cargo build --release --bin block-oracle
 
 
-FROM alpine:latest as runtime
+FROM debian:latest as runtime
 WORKDIR /app
 
-RUN apk add --no-cache openssl-dev
+RUN apt-get update -y && \
+	apt-get install -y libc-dev pkg-config libssl-dev ca-certificates
+
 COPY --from=builder /app/target/release/block-oracle /usr/local/bin
 COPY --from=builder /app/crates/oracle/config/staging/config.toml ./config.toml
 


### PR DESCRIPTION
Trying again with Debian, because `cargo-chef` plays nicer with it.