### PR TITLE
feat: update canonical graphql query

### DIFF
--- a/crates/oracle/src/graphql/query.graphql
+++ b/crates/oracle/src/graphql/query.graphql
@@ -4,13 +4,11 @@ query SubgraphState {
     networks(orderBy: arrayIndex, orderDirection: asc) {
       id
       arrayIndex
-      blockNumbers(first: 1, orderBy: blockNumber, orderDirection: desc) {
+      blockNumbers(first: 1, orderBy: epochNumber, orderDirection: desc) {
         blockNumber
         acceleration
         delta
-        epoch {
-          epochNumber
-        }
+        epochNumber
       }
     }
     encodingVersion


### PR DESCRIPTION
This is a temporary workaround as Graph Node don't support ordering by child entities yet.

In the future, we could revert this commit and order by the nested `epochNumber` field.