### PR TITLE
fix: remove `prep:local` step from the `deploy-local` script

### DIFF
--- a/packages/subgraph/package.json
+++ b/packages/subgraph/package.json
@@ -10,7 +10,7 @@
     "deploy-staging": "yarn codegen && yarn prep:staging && graph build --network goerli && graph deploy --node https://api.thegraph.com/deploy/ juanmardefago/block-oracle",
     "create-local": "graph create --node http://127.0.0.1:8020/ edgeandnode/block-oracle",
     "remove-local": "graph remove --node http://127.0.0.1:8020/ edgeandnode/block-oracle",
-    "deploy-local": "yarn codegen && yarn prep:local && graph deploy --node http://127.0.0.1:8020/ --ipfs http://localhost:${IPFS_PORT} edgeandnode/block-oracle --version-label 0.1.0",
+    "deploy-local": "yarn codegen && graph deploy --node http://127.0.0.1:8020/ --ipfs http://localhost:${IPFS_PORT} edgeandnode/block-oracle --version-label 0.1.0",
     "prep:local": "mustache ./config/local.json subgraph.template.yaml > subgraph.yaml && mustache ./config/local.json src/constants.template.ts > src/constants.ts",
     "prep:test": "mustache ./config/test.json subgraph.template.yaml > subgraph.yaml && mustache ./config/test.json src/constants.template.ts > src/constants.ts",
     "prep:prod": "mustache ./config/prod.json subgraph.template.yaml > subgraph.yaml && mustache ./config/prod.json src/constants.template.ts > src/constants.ts",


### PR DESCRIPTION
This step undoes other steps in the [`deploy-subgraph` overmind process file](https://github.com/graphprotocol/block-oracle/blob/116b8ddaf9dbcdc216a07b3d71eaf1bcd9954703/.local/deploy-subgraph.sh).
