### PR TITLE
Freshness detection, part I

### DIFF
--- a/crates/oracle/src/graphql/query.graphql
+++ b/crates/oracle/src/graphql/query.graphql
@@ -1,4 +1,9 @@
 query SubgraphState {
+  _meta {
+    block {
+      number
+    }
+  }
   globalState(id: "0") {
     activeNetworkCount
     networks(orderBy: arrayIndex, orderDirection: asc) {

--- a/crates/oracle/src/graphql/schema.graphql
+++ b/crates/oracle/src/graphql/schema.graphql
@@ -1,5 +1,14 @@
 type Query {
   globalState(id: String!): GlobalState
+  _meta: Meta,
+}
+
+type Meta {
+  block: Block!
+}
+
+type Block {
+  number: Int!
 }
 
 type GlobalState {

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -181,6 +181,7 @@ impl Oracle {
             .subgraph_state
             .last_state()
             .expect("expected data from a valid subgraph state, but found none")
+            .1
             .networks
             .iter()
             .map(|network| {


### PR DESCRIPTION
This is the first part of freshness module integration. For now, we're only detecting subgraph freshness and not doing anything about it besides logging relevant information. A subsequent PR will cause an `Error` to be thrown and make the oracle wait some time before polling again.