### PR TITLE
Integrate freshness check module with Oracle::run and fail gracefully upon indexed chains' JRPC failure

### DIFF
--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -4,7 +4,7 @@ mod serialize;
 
 use merkle::{merkle_root, MerkleLeaf};
 use messages::*;
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub use messages::{BlockPtr, CompressedMessage, CompressedSetBlockNumbersForNextEpoch, Message};
 pub use serialize::serialize_messages;
@@ -146,7 +146,7 @@ impl Encoder {
     /// network indices.
     fn sort_network_data_by_index<T>(
         &self,
-        chain_data: &HashMap<String, T>,
+        chain_data: &BTreeMap<String, T>,
     ) -> Result<Vec<T>, Error>
     where
         T: Clone,
@@ -167,13 +167,29 @@ impl Encoder {
         Ok(sorted.into_iter().map(|(_, x)| x).collect())
     }
 
-    fn compress_block_ptrs(&mut self, block_ptrs: &HashMap<String, BlockPtr>) -> Result<(), Error> {
+    fn compress_block_ptrs(
+        &mut self,
+        block_ptrs: &BTreeMap<String, BlockPtr>,
+    ) -> Result<(), Error> {
+        let mut block_ptrs = block_ptrs.clone();
+        for network in &self.networks {
+            if block_ptrs.contains_key(&network.0) {
+                block_ptrs.insert(
+                    network.0.clone(),
+                    BlockPtr {
+                        number: network.1.block_number,
+                        hash: [0; 32],
+                    },
+                );
+            }
+        }
+
         // Prepare to get accelerations and merkle leaves based on previous deltas.
         let mut accelerations = Vec::with_capacity(block_ptrs.len());
         let mut merkle_leaves = Vec::with_capacity(block_ptrs.len());
 
         // Sort the block pointers by network index.
-        let sorted_block_ptrs = self.sort_network_data_by_index(block_ptrs)?;
+        let sorted_block_ptrs = self.sort_network_data_by_index(&block_ptrs)?;
 
         for (i, ptr) in sorted_block_ptrs.into_iter().enumerate() {
             let network_data = &self.networks[i].1;
@@ -226,7 +242,6 @@ mod tests {
     use {
         super::*,
         crate::messages::{BlockPtr, Message},
-        std::collections::HashMap,
         tokio::test,
     };
 
@@ -236,7 +251,7 @@ mod tests {
 
         // Skip some empty epochs
         for _ in 0..20 {
-            messages.push(Message::SetBlockNumbersForNextEpoch(HashMap::new()));
+            messages.push(Message::SetBlockNumbersForNextEpoch(BTreeMap::new()));
         }
 
         let networks: Vec<_> = ["A:1991", "B:2kl", "C:190", "D:18818"]

--- a/crates/encoding/src/messages.rs
+++ b/crates/encoding/src/messages.rs
@@ -1,4 +1,4 @@
-use std::collections::HashMap;
+use std::collections::BTreeMap;
 
 pub type NetworkIndex = u64;
 pub type Bytes32 = [u8; 32];
@@ -21,7 +21,7 @@ impl std::fmt::Debug for BlockPtr {
 #[derive(Debug, Clone)]
 pub enum Message {
     // TODO: Consider specifying epoch number here?
-    SetBlockNumbersForNextEpoch(HashMap<String, BlockPtr>),
+    SetBlockNumbersForNextEpoch(BTreeMap<String, BlockPtr>),
     RegisterNetworks {
         // Remove is by index
         remove: Vec<NetworkIndex>,
@@ -30,7 +30,7 @@ pub enum Message {
     },
     CorrectEpochs {
         // TODO: include hash, count, and (if count is nonzero) merkle root
-        data_by_network_id: HashMap<NetworkIndex, EpochDetails>,
+        data_by_network_id: BTreeMap<NetworkIndex, EpochDetails>,
     },
     UpdateVersion {
         version_number: u64,
@@ -42,7 +42,7 @@ pub enum Message {
 pub enum CompressedMessage {
     SetBlockNumbersForNextEpoch(CompressedSetBlockNumbersForNextEpoch),
     CorrectEpochs {
-        data_by_network_id: HashMap<NetworkIndex, EpochDetails>,
+        data_by_network_id: BTreeMap<NetworkIndex, EpochDetails>,
     },
     RegisterNetworks {
         remove: Vec<u64>,

--- a/crates/oracle-encoder/src/main.rs
+++ b/crates/oracle-encoder/src/main.rs
@@ -1,7 +1,7 @@
 use clap::Parser;
 use epoch_encoding as ee;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{collections::HashMap, io};
+use std::{collections::BTreeMap, io};
 
 #[derive(Parser)]
 #[clap(name = "oracle-encoder")]
@@ -32,7 +32,7 @@ fn main() -> io::Result<()> {
                 Message::CorrectEpochs {} => (
                     "CorrectEpochs",
                     ee::CompressedMessage::CorrectEpochs {
-                        data_by_network_id: HashMap::new(),
+                        data_by_network_id: BTreeMap::new(),
                     },
                 ),
                 Message::UpdateVersion { version_number } => ("UpdateVersion", {

--- a/crates/oracle/src/models.rs
+++ b/crates/oracle/src/models.rs
@@ -24,7 +24,7 @@ where
 }
 
 /// See https://github.com/ChainAgnostic/CAIPs/blob/master/CAIPs/caip-2.md.
-#[derive(Debug, Clone, PartialEq, Eq, Hash, DeserializeFromStr)]
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash, DeserializeFromStr)]
 #[repr(transparent)]
 pub struct Caip2ChainId {
     chain_id: String,

--- a/crates/oracle/src/networks_diff.rs
+++ b/crates/oracle/src/networks_diff.rs
@@ -3,17 +3,17 @@ use std::collections::{HashMap, HashSet};
 
 #[derive(Debug, Clone)]
 pub struct NetworksDiff {
-    pub deletions: HashMap<Caip2ChainId, u32>,
-    pub insertions: HashMap<Caip2ChainId, u32>,
+    pub deletions: HashMap<Caip2ChainId, u64>,
+    pub insertions: HashMap<Caip2ChainId, u64>,
 }
 
 impl NetworksDiff {
-    pub fn calculate(subgraph_networks: HashMap<Caip2ChainId, u32>, config: &Config) -> Self {
+    pub fn calculate(subgraph_networks: HashMap<Caip2ChainId, u64>, config: &Config) -> Self {
         let new = config.indexed_chains.iter().map(|c| c.id.clone()).collect();
         Self::diff(subgraph_networks, new)
     }
 
-    fn diff(old: HashMap<Caip2ChainId, u32>, new: Vec<Caip2ChainId>) -> Self {
+    fn diff(old: HashMap<Caip2ChainId, u64>, new: Vec<Caip2ChainId>) -> Self {
         // Turn `new` into a `HashSet` to easily check for the presence of
         // items.
         let new: HashSet<Caip2ChainId> = new.into_iter().collect();

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -5,7 +5,7 @@ use crate::{
     SubgraphQuery, SubgraphStateTracker,
 };
 use epoch_encoding::{self as ee, BlockPtr, Encoder, Message, CURRENT_ENCODING_VERSION};
-use std::collections::{HashMap, HashSet};
+use std::collections::{BTreeMap, HashSet};
 use tracing::{debug, error, info, warn};
 use web3::{
     contract::{Contract, Options},
@@ -14,7 +14,7 @@ use web3::{
 
 const CONTRACT_FUNCTION_NAME: &'static str = "crossChainEpochOracle";
 
-/// The main application in-memory state
+/// The main application in-memory state.
 pub struct Oracle {
     config: &'static Config,
     epoch_tracker: EpochTracker,
@@ -56,35 +56,47 @@ impl Oracle {
         }
     }
 
+    /// Runs a new polling iteration and submits new messages to the subgraph,
+    /// if necessary.
     pub async fn run(&mut self) -> Result<(), Error> {
+        info!("New polling iteration.");
+        if !self.detect_new_epoch().await? {
+            debug!("No epoch change detected.");
+            return Ok(());
+        }
+
+        info!("Entering a new epoch.");
+        self.handle_new_epoch().await?;
+
+        Ok(())
+    }
+
+    async fn detect_new_epoch(&mut self) -> Result<bool, Error> {
         let block = get_latest_block(self.protocol_chain.web3.clone())
             .await
-            .map_err(Error::BadJrpcProtocolChain)?
-            .expect("Can't get latest block prom protocol chain");
+            .map_err(Error::BadJrpcProtocolChain)?;
         debug!(
-            block = block.number,
+            number = block.number,
             hash = hex::encode(block.hash).as_str(),
             "Got the latest block from the protocol chain."
         );
 
+        debug!("Querying the subgraph state...");
         self.subgraph_state.refresh().await;
         if let Some(subgraph_error) = self.subgraph_state.error() {
-            error!(error = %subgraph_error, "Found an error when fetching the subgraph latest state");
-            return Ok(());
+            return Err(Error::Subgraph(subgraph_error));
         }
 
         let last_block_number_indexed_by_subgraph =
-            self.subgraph_state.last_state().map(|state| state.0);
-
-        let is_new_epoch = last_block_number_indexed_by_subgraph.is_some()
-            || self.epoch_tracker.is_new_epoch(block.number).await?;
-
-        if !is_new_epoch {
-            return Ok(());
-        }
+            if let Some(state) = self.subgraph_state.last_state() {
+                state.0
+            } else {
+                warn!("The subgraph state is uninitialized");
+                0
+            };
 
         let is_fresh = freshness::subgraph_is_fresh(
-            last_block_number_indexed_by_subgraph.unwrap_or(0).into(),
+            last_block_number_indexed_by_subgraph.into(),
             block.number.into(),
             self.protocol_chain.clone(),
             self.config.owner_address,
@@ -92,21 +104,42 @@ impl Oracle {
             self.config.freshness_threshold,
         )
         .await
-        .unwrap();
-
-        // FIXME
+        .map_err(Error::BadJrpcProtocolChain)?;
         if !is_fresh {
-            warn!("Subgraph is not fresh");
+            error!("Subgraph is not fresh");
+            return Err(Error::SubgraphNotFresh);
         }
 
-        info!("Entering a new epoch.");
+        Ok(self.epoch_tracker.is_new_epoch(block.number).await?)
+    }
+
+    async fn handle_new_epoch(&mut self) -> Result<(), Error> {
         info!("Collecting latest block information from all indexed chains.");
-        // Get indexed chains' latest blocks.
-        let latest_blocks = get_latest_blocks(&self.indexed_chains).await?;
+
+        let latest_blocks_res = get_latest_blocks(&self.indexed_chains).await;
+        let latest_blocks = latest_blocks_res
+            .iter()
+            .filter_map(|(chain_id, res)| match res {
+                Ok(block) => Some((chain_id.clone(), block.clone())),
+                Err(e) => {
+                    warn!(
+                        chain_id = chain_id.as_str(),
+                        error = e.to_string().as_str(),
+                        "Failed to get latest block from chain. Skipping."
+                    );
+                    None
+                }
+            })
+            .collect();
+
         let payload = self.produce_next_payload(latest_blocks)?;
-        submit_call(self.config, self.protocol_chain.clone(), payload)
+        let tx_hash = submit_call(self.config, self.protocol_chain.clone(), payload)
             .await
             .map_err(Error::CantSubmitTx)?;
+        info!(
+            tx_hash = tx_hash.to_string().as_str(),
+            "Contract call submitted successfully."
+        );
 
         // TODO: After broadcasting a transaction to the protocol chain and getting a transaction
         // receipt, we should monitor it until it get enough confirmations. It's unclear which
@@ -117,10 +150,9 @@ impl Oracle {
 
     fn produce_next_payload(
         &self,
-        latest_blocks: HashMap<Caip2ChainId, BlockPtr>,
+        latest_blocks: BTreeMap<Caip2ChainId, BlockPtr>,
     ) -> Result<Vec<u8>, Error> {
-        info!("A new epoch started in the protocol chain");
-        let registered_networks = self.registered_networks()?;
+        let registered_networks = registered_networks(&self.subgraph_state);
 
         let mut messages = vec![];
 
@@ -130,13 +162,7 @@ impl Oracle {
             // `NetworksDiff::calculate` uses u32's but `registered_networks` has u64's
             let networks_and_block_numbers = registered_networks
                 .iter()
-                .map(|(chain_id, network)| {
-                    let block_number = u32::try_from(network.block_number).expect(&format!(
-                        "expected a block number that would fit a u32, but found {}",
-                        network.block_number
-                    ));
-                    (chain_id.clone(), block_number)
-                })
+                .map(|(chain_id, network)| (chain_id.clone(), network.block_number))
                 .collect();
             NetworksDiff::calculate(networks_and_block_numbers, self.config)
         };
@@ -189,20 +215,13 @@ impl Oracle {
         );
         Ok(encoded)
     }
+}
 
-    fn registered_networks(&self) -> Result<Vec<(Caip2ChainId, epoch_encoding::Network)>, Error> {
-        if self.subgraph_state.is_failed() {
-            todo!("Handle this as an error")
-        }
-        if self.subgraph_state.is_uninitialized() {
-            info!("Epoch Subgraph contains no initial state");
-            return Ok(Default::default());
-        };
-        info!("subgraph data is {:?}", self.subgraph_state.last_state());
-        Ok(self
-            .subgraph_state
-            .last_state()
-            .expect("expected data from a valid subgraph state, but found none")
+fn registered_networks(
+    subgraph_state: &SubgraphStateTracker<SubgraphQuery>,
+) -> Vec<(Caip2ChainId, ee::Network)> {
+    if let Some(state) = subgraph_state.last_state() {
+        state
             .1
             .networks
             .iter()
@@ -215,11 +234,14 @@ impl Oracle {
                     },
                 )
             })
-            .collect())
+            .collect()
+    } else {
+        // The subgraph is uninitialized, so there's no registered networks at all.
+        vec![]
     }
 }
 
-fn latest_blocks_to_message(latest_blocks: HashMap<Caip2ChainId, BlockPtr>) -> ee::Message {
+fn latest_blocks_to_message(latest_blocks: BTreeMap<Caip2ChainId, BlockPtr>) -> ee::Message {
     Message::SetBlockNumbersForNextEpoch(
         latest_blocks
             .into_iter()
@@ -273,17 +295,8 @@ where
 
 mod freshness {
     use crate::{jrpc_utils::calls_in_block_range, models::JrpcProviderForChain};
-    use thiserror::Error;
-    use tracing::{debug, error, trace};
+    use tracing::{debug, trace};
     use web3::types::{H160, U64};
-
-    #[derive(Debug, Error)]
-    pub enum FreshnessCheckError {
-        #[error("Epoch Subgraph advanced beyond protocol chain's head")]
-        SubgraphBeyondChain,
-        #[error(transparent)]
-        Web3(#[from] web3::Error),
-    }
 
     /// The Epoch Subgraph is considered fresh if it has processed all relevant transactions
     /// targeting the DataEdge contract.
@@ -303,15 +316,13 @@ mod freshness {
         owner_address: H160,
         contract_address: H160,
         freshness_threshold: u64,
-    ) -> Result<bool, FreshnessCheckError>
+    ) -> web3::Result<bool>
     where
         T: web3::Transport,
     {
         // If this ever happens, then there must be a serious bug in the code
         if subgraph_latest_block > current_block {
-            let anomaly = FreshnessCheckError::SubgraphBeyondChain;
-            error!(%anomaly);
-            return Err(anomaly);
+            return Ok(true);
         }
         let block_distance = (current_block - subgraph_latest_block).as_u64();
         if block_distance == 0 {
@@ -329,8 +340,7 @@ mod freshness {
         // Scan the blocks in betwenn for transactions from the Owner to the Data Edge contract
         let calls = calls_in_block_range(
             protocol_chain.web3,
-            subgraph_latest_block,
-            current_block,
+            subgraph_latest_block.as_u64()..=current_block.as_u64(),
             owner_address,
             contract_address,
         )

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -1,10 +1,11 @@
+use std::sync::Arc;
+
 use crate::models::Caip2ChainId;
 use anyhow::ensure;
 use async_trait::async_trait;
 use graphql_client::{GraphQLQuery, Response};
 use itertools::Itertools;
 use reqwest::Url;
-use std::sync::Arc;
 use tracing::{error, info};
 
 pub struct SubgraphQuery {
@@ -93,7 +94,7 @@ where
     A: SubgraphApi,
 {
     last_state: Option<A::State>,
-    error: Option<Arc<anyhow::Error>>,
+    error: Option<Arc<A::Error>>,
     subgraph_api: A,
 }
 
@@ -101,7 +102,6 @@ impl<A> SubgraphStateTracker<A>
 where
     A: SubgraphApi,
     A::State: Clone,
-    A::Error: Into<anyhow::Error>,
 {
     pub fn new(api: A) -> Self {
         Self {
@@ -127,7 +127,7 @@ where
         self.last_state.as_ref()
     }
 
-    pub fn error(&self) -> Option<Arc<anyhow::Error>> {
+    pub fn error(&self) -> Option<Arc<A::Error>> {
         self.error.clone()
     }
 
@@ -144,7 +144,7 @@ where
                 if self.is_failed() {
                     error!("Failed to retrieve state from a previously failed subgraph");
                 }
-                self.error = Some(Arc::new(err.into()));
+                self.error = Some(Arc::new(err));
             }
         }
     }


### PR DESCRIPTION
- Favor `BTreeMap` instead of `HashMap`.
- Improved return types: `get_latest_block` doesn't return `Ok(None)` anymore; rather, `None` is now translated into a `web3::Error` which would only ever be caused by a faulty JRPC provider.
- `get_latest_blocks` now has a `web3::Result` per chain, rather than failing the whole function call whenever a single `Web3` query fails.
- Faster, cheaper, and simpler `calls_in_block_range` by using [`Eth::block_with_txs`](https://docs.rs/web3/latest/web3/api/struct.Eth.html#method.block_with_txs) rather than [`Eth::block`](https://docs.rs/web3/latest/web3/api/struct.Eth.html#method.block) + [`Eth::transaction`](https://docs.rs/web3/latest/web3/api/struct.Eth.html#method.transaction).
- Less redundant logging. I've removed logs there were redundant (e.s. logging the same information both at the call site and at the beginning of the function body) and added some where useful.
- `NetworksDiff` now uses `u64` internally, for consistency with the rest of the code.
- Removed redundant subgraph state checks in `registered_networks`. `Oracle::run` already makes sure that the subgraph is not failed, so no need to do it twice.
- `Oracle::run` now checks for subgraph freshness immediately after querying the subgraph.
- Small changes to error types in `SubgraphQuery`.