### PR TITLE
Set appropriate wait times upon subgraph failure

### DIFF
--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -55,7 +55,7 @@ impl MainLoopFlow for Error {
     fn instruction(&self) -> OracleControlFlow {
         use Error::*;
         match self {
-            Subgraph(_) => OracleControlFlow::Continue(None),
+            Subgraph(err) => err.instruction(),
             BadJrpcProtocolChain(_) => OracleControlFlow::Continue(None),
             BadJrpcIndexedChain { .. } => OracleControlFlow::Continue(None),
             EpochTracker(epoch_tracker) => epoch_tracker.instruction(),


### PR DESCRIPTION
At the present state, the oracle doesn't react at all to subgraph failure and instead simply keeps polling without additional wait times. This is the correct behavior in some circumstances (e.g. connectivity issues aka `SubgraphQueryError::Transport`) but not others (e.g. failed subgraph, cause we can't do nothing about it).

This PR sets a 1 minute wait for connectivity issues, and 10 minutes for other subgraph failures.