### PR TITLE
Fix zero'd block number updates from the oracle

### DIFF
--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -184,7 +184,7 @@ impl Encoder {
     ) -> Result<(), Error> {
         let mut block_ptrs = block_ptrs.clone();
         for network in &self.networks {
-            if block_ptrs.contains_key(&network.0) {
+            if !block_ptrs.contains_key(&network.0) {
                 block_ptrs.insert(
                     network.0.clone(),
                     BlockPtr {

--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -30,6 +30,15 @@ pub struct Network {
     pub block_delta: i64,
 }
 
+impl Network {
+    pub fn new(block_number: u64, block_delta: i64) -> Self {
+        Self {
+            block_number,
+            block_delta,
+        }
+    }
+}
+
 /// The [`Encoder`]'s job is to take in sequences of high-level [`Message`]s, compress them,
 /// perform validation, and spit out bytes.
 ///
@@ -101,7 +110,7 @@ impl Encoder {
                 if block_ptrs.is_empty() {
                     self.compress_empty_block_ptrs();
                 } else {
-                    self.compress_block_ptrs(block_ptrs)?;
+                    self.compress_block_ptrs(block_ptrs.clone())?;
                 }
             }
             Message::RegisterNetworks { remove, add } => {
@@ -180,17 +189,13 @@ impl Encoder {
 
     fn compress_block_ptrs(
         &mut self,
-        block_ptrs: &BTreeMap<String, BlockPtr>,
+        mut block_ptrs: BTreeMap<String, BlockPtr>,
     ) -> Result<(), Error> {
-        let mut block_ptrs = block_ptrs.clone();
         for network in &self.networks {
             if !block_ptrs.contains_key(&network.0) {
                 block_ptrs.insert(
                     network.0.clone(),
-                    BlockPtr {
-                        number: network.1.block_number,
-                        hash: [0; 32],
-                    },
+                    BlockPtr::new(network.1.block_number, [0; 32]),
                 );
             }
         }
@@ -253,11 +258,38 @@ mod tests {
     use {
         super::*,
         crate::messages::{BlockPtr, Message},
-        tokio::test,
     };
 
     #[test]
-    async fn pipeline() {
+    fn block_numbers_increase() {
+        let networks = vec![
+            ("A:1".to_string(), Network::new(0, 0)),
+            ("B:2".to_string(), Network::new(100, 0)),
+        ];
+        let mut encoder = Encoder::new(CURRENT_ENCODING_VERSION, networks).unwrap();
+
+        let block_updates = vec![
+            ("A:1".to_string(), BlockPtr::new(1, [0; 32])),
+            ("B:2".to_string(), BlockPtr::new(250, [0; 32])),
+        ];
+        encoder
+            .compress(&Message::SetBlockNumbersForNextEpoch(
+                block_updates.into_iter().collect(),
+            ))
+            .unwrap();
+
+        let accelerations = encoder
+            .compressed
+            .last()
+            .unwrap()
+            .as_non_empty_block_numbers()
+            .unwrap()
+            .0;
+        assert_eq!(accelerations, [1, 150]);
+    }
+
+    #[test]
+    fn pipeline() {
         let mut messages = Vec::new();
 
         // Skip some empty epochs

--- a/crates/encoding/src/messages.rs
+++ b/crates/encoding/src/messages.rs
@@ -9,6 +9,12 @@ pub struct BlockPtr {
     pub hash: Bytes32,
 }
 
+impl BlockPtr {
+    pub fn new(number: u64, hash: Bytes32) -> Self {
+        BlockPtr { number, hash }
+    }
+}
+
 impl std::fmt::Debug for BlockPtr {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("BlockPtr")
@@ -58,6 +64,20 @@ pub enum CompressedMessage {
         new_owner_address: [u8; 20],
     },
     Reset,
+}
+
+impl CompressedMessage {
+    pub fn as_non_empty_block_numbers(&self) -> Option<(&[i64], Bytes32)> {
+        match self {
+            CompressedMessage::SetBlockNumbersForNextEpoch(
+                CompressedSetBlockNumbersForNextEpoch::NonEmpty {
+                    accelerations,
+                    root,
+                },
+            ) => Some((accelerations, *root)),
+            _ => None,
+        }
+    }
 }
 
 #[derive(Clone, Debug, PartialEq, Eq)]


### PR DESCRIPTION
The fix is easy enough. We're supposed to set a zero increment for all networks that don't have a block number update, but were doing the exact opposite due to a faulty conditional; i.e. setting a zero increment for all networks that *did* have a block number update.

Includes a regression test.

Closes https://github.com/graphprotocol/block-oracle/issues/162.