### PR TITLE
Make sure `Encoder` state is modified appropriately every time we send messages

### DIFF
--- a/crates/encoding/src/lib.rs
+++ b/crates/encoding/src/lib.rs
@@ -45,7 +45,7 @@ impl Network {
 /// # Panics
 ///
 /// The [`Encoder`] should never panic on malformed [`Message`]s, but rather return an [`Error`].
-#[derive(Clone, Debug)]
+#[derive(Clone, Debug, PartialEq, Eq)]
 pub struct Encoder {
     networks: Vec<(String, Network)>,
     encoding_version: u64,

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -251,6 +251,7 @@ impl Oracle {
 
         let mut compression_engine = Encoder::new(CURRENT_ENCODING_VERSION, available_networks)
             .expect("Can't prepare for encoding because something went wrong.");
+        let compression_engine_initially = compression_engine.clone();
 
         let encoded = compression_engine
             .encode(&messages[..])
@@ -261,6 +262,13 @@ impl Oracle {
             encoded = hex_string(&encoded).as_str(),
             "Successfully encoded message(s)."
         );
+
+        assert_ne!(
+            compression_engine, compression_engine_initially,
+            "The encoder has identical internal state compared to what \
+            it had before these new messages. This is a bug!"
+        );
+
         Ok(encoded)
     }
 }


### PR DESCRIPTION
Closes #https://github.com/graphprotocol/block-oracle/issues/32.