### PR TITLE
fix: prevent the oracle from sleeping twice when handling errors

### DIFF
--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -88,6 +88,7 @@ async fn main() -> Result<(), Error> {
     while !CTRLC_HANDLER.poll_ctrlc() {
         if let Err(err) = oracle.run().await {
             handle_error(err).await?;
+            continue;
         }
 
         // After every polling iteration, we go to sleep for a bit. Wouldn't


### PR DESCRIPTION
Currently, the Oracle sleeps twice: both as a response to a recoverable error and by the end of each iteration cycle. 

This fix makes it jump back to the start of the main loop right after sleeping due to recoverable errors.