### PR TITLE
`oracle-encoder`: Output calldata

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -333,10 +333,22 @@ version = "0.20.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7774144344a4faa177370406a7ff5f1da24303817368584c6206c8303eb07848"
 dependencies = [
- "funty",
- "radium",
+ "funty 1.1.0",
+ "radium 0.6.2",
  "tap",
- "wyz",
+ "wyz 0.2.0",
+]
+
+[[package]]
+name = "bitvec"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
+dependencies = [
+ "funty 2.0.0",
+ "radium 0.7.0",
+ "tap",
+ "wyz 0.5.0",
 ]
 
 [[package]]
@@ -694,11 +706,28 @@ version = "16.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a4c98847055d934070b90e806e12d3936b787d0a115068981c1d8dfd5dfef5a5"
 dependencies = [
- "ethereum-types",
+ "ethereum-types 0.12.1",
  "hex",
  "serde",
  "serde_json",
- "sha3",
+ "sha3 0.9.1",
+ "thiserror",
+ "uint",
+]
+
+[[package]]
+name = "ethabi"
+version = "17.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e4966fba78396ff92db3b817ee71143eccd98acf0f876b8d600e585a670c5d1b"
+dependencies = [
+ "ethereum-types 0.13.1",
+ "hex",
+ "once_cell",
+ "regex",
+ "serde",
+ "serde_json",
+ "sha3 0.10.2",
  "thiserror",
  "uint",
 ]
@@ -717,16 +746,43 @@ dependencies = [
 ]
 
 [[package]]
+name = "ethbloom"
+version = "0.12.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "11da94e443c60508eb62cf256243a64da87304c2802ac2528847f79d750007ef"
+dependencies = [
+ "crunchy",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "tiny-keccak",
+]
+
+[[package]]
 name = "ethereum-types"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05136f7057fe789f06e6d41d07b34e6f70d8c86e5693b60f97aaa6553553bdaf"
 dependencies = [
- "ethbloom",
+ "ethbloom 0.11.1",
  "fixed-hash",
  "impl-rlp",
  "impl-serde",
- "primitive-types",
+ "primitive-types 0.10.1",
+ "uint",
+]
+
+[[package]]
+name = "ethereum-types"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b2827b94c556145446fcce834ca86b7abf0c39a805883fe20e72c5bfdb5a0dc6"
+dependencies = [
+ "ethbloom 0.12.1",
+ "fixed-hash",
+ "impl-rlp",
+ "impl-serde",
+ "primitive-types 0.11.1",
  "uint",
 ]
 
@@ -825,6 +881,12 @@ name = "funty"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+
+[[package]]
+name = "funty"
+version = "2.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -1186,7 +1248,16 @@ version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "161ebdfec3c8e3b52bf61c4f3550a1eea4f9579d10dc1b936f3171ebdcd6c443"
 dependencies = [
- "parity-scale-codec",
+ "parity-scale-codec 2.3.1",
+]
+
+[[package]]
+name = "impl-codec"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ba6a270039626615617f3f36d15fc827041df3b78c439da2cadfa47455a77f2f"
+dependencies = [
+ "parity-scale-codec 3.1.5",
 ]
 
 [[package]]
@@ -1526,6 +1597,7 @@ version = "0.1.0"
 dependencies = [
  "clap",
  "epoch-encoding",
+ "ethabi 17.2.0",
  "hex",
  "serde",
  "serde_json",
@@ -1544,10 +1616,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "373b1a4c1338d9cd3d1fa53b3a11bdab5ab6bd80a20f7f7becd76953ae2be909"
 dependencies = [
  "arrayvec",
- "bitvec",
+ "bitvec 0.20.4",
  "byte-slice-cast",
  "impl-trait-for-tuples",
- "parity-scale-codec-derive",
+ "parity-scale-codec-derive 2.3.1",
+ "serde",
+]
+
+[[package]]
+name = "parity-scale-codec"
+version = "3.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9182e4a71cae089267ab03e67c99368db7cd877baf50f931e5d6d4b71e195ac0"
+dependencies = [
+ "arrayvec",
+ "bitvec 1.0.1",
+ "byte-slice-cast",
+ "impl-trait-for-tuples",
+ "parity-scale-codec-derive 3.1.3",
  "serde",
 ]
 
@@ -1556,6 +1642,18 @@ name = "parity-scale-codec-derive"
 version = "2.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1557010476e0595c9b568d16dcfb81b93cdeb157612726f5170d31aa707bed27"
+dependencies = [
+ "proc-macro-crate",
+ "proc-macro2",
+ "quote",
+ "syn",
+]
+
+[[package]]
+name = "parity-scale-codec-derive"
+version = "3.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9299338969a3d2f491d65f140b00ddec470858402f888af98e8642fb5e8965cd"
 dependencies = [
  "proc-macro-crate",
  "proc-macro2",
@@ -1649,7 +1747,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05e4722c697a58a99d5d06a08c30821d7c082a4632198de1eaa5a6c22ef42373"
 dependencies = [
  "fixed-hash",
- "impl-codec",
+ "impl-codec 0.5.1",
+ "impl-rlp",
+ "impl-serde",
+ "uint",
+]
+
+[[package]]
+name = "primitive-types"
+version = "0.11.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e28720988bff275df1f51b171e1b2a18c30d194c4d2b61defdacecd625a5d94a"
+dependencies = [
+ "fixed-hash",
+ "impl-codec 0.6.0",
  "impl-rlp",
  "impl-serde",
  "uint",
@@ -1733,6 +1844,12 @@ name = "radium"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "643f8f41a8ebc4c5dc4515c82bb8abd397b527fc20fd681b7c011c2aee5d44fb"
+
+[[package]]
+name = "radium"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rand"
@@ -2055,6 +2172,16 @@ dependencies = [
  "digest 0.9.0",
  "keccak",
  "opaque-debug",
+]
+
+[[package]]
+name = "sha3"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0a31480366ec990f395a61b7c08122d99bd40544fdb5abcfc1b06bb29994312c"
+dependencies = [
+ "digest 0.10.3",
+ "keccak",
 ]
 
 [[package]]
@@ -2621,8 +2748,8 @@ dependencies = [
  "base64",
  "bytes",
  "derive_more",
- "ethabi",
- "ethereum-types",
+ "ethabi 16.0.0",
+ "ethereum-types 0.12.1",
  "futures",
  "futures-timer",
  "headers",
@@ -2747,6 +2874,15 @@ name = "wyz"
 version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+
+[[package]]
+name = "wyz"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30b31594f29d27036c383b53b59ed3476874d518f0efb151b27a4c275141390e"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "xshell"

--- a/crates/oracle-encoder/Cargo.toml
+++ b/crates/oracle-encoder/Cargo.toml
@@ -6,6 +6,7 @@ edition = "2021"
 [dependencies]
 clap = { version = "3", features = ["derive"] }
 epoch-encoding = { path = "../encoding" }
+ethabi = "17.2.0"
 hex = "0.4"
 serde = { version = "1", features = ["derive"] }
 serde_json = "1"

--- a/crates/oracle-encoder/src/main.rs
+++ b/crates/oracle-encoder/src/main.rs
@@ -1,15 +1,15 @@
 use clap::Parser;
 use epoch_encoding as ee;
 use serde::{Deserialize, Deserializer, Serialize};
-use std::{collections::BTreeMap, io};
+use std::{collections::BTreeMap, io, path::PathBuf};
 
 #[derive(Parser)]
 #[clap(name = "oracle-encoder")]
 #[clap(bin_name = "oracle-encoder")]
 #[clap(author, version, about, long_about = None)]
 struct OracleEncoder {
-    #[clap(long)]
-    json_path: String,
+    #[clap()]
+    json_path: PathBuf,
 }
 
 fn main() -> io::Result<()> {

--- a/crates/oracle-encoder/src/main.rs
+++ b/crates/oracle-encoder/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Parser;
 use epoch_encoding as ee;
+use ethabi::{encode, short_signature, ParamType, Token};
 use serde::{Deserialize, Deserializer, Serialize};
 use std::{collections::BTreeMap, io, path::PathBuf};
 
@@ -8,8 +9,12 @@ use std::{collections::BTreeMap, io, path::PathBuf};
 #[clap(bin_name = "oracle-encoder")]
 #[clap(author, version, about, long_about = None)]
 struct OracleEncoder {
-    #[clap()]
+    /// The path to the JSON file containing the message block.
     json_path: PathBuf,
+
+    /// Whether to output the full calldata instead of just the payload.
+    #[clap(short, long, action)]
+    calldata: bool,
 }
 
 fn main() -> io::Result<()> {
@@ -78,14 +83,21 @@ fn main() -> io::Result<()> {
         encoded_message_blocks.push((message_types, payload));
     }
 
-    for (i, (message_types, block_payload)) in encoded_message_blocks.iter().enumerate() {
-        println!(
-            "{} ({}): 0x{}",
-            i + 1,
-            message_types.join(", "),
-            hex::encode(block_payload)
-        );
-    }
+    if inputs.calldata {
+        for (_, block_payload) in encoded_message_blocks.into_iter() {
+            let calldata = calldata(block_payload);
+            println!("{}", hex::encode(calldata));
+        }
+    } else {
+        for (i, (message_types, block_payload)) in encoded_message_blocks.iter().enumerate() {
+            println!(
+                "{} ({}): 0x{}",
+                i + 1,
+                message_types.join(", "),
+                hex::encode(block_payload)
+            );
+        }
+    };
 
     Ok(())
 }
@@ -142,4 +154,11 @@ where
 {
     let s = String::deserialize(deserializer)?;
     hex::decode(s.strip_prefix("0x").unwrap_or(s.as_str())).map_err(serde::de::Error::custom)
+}
+
+pub fn calldata(payload: Vec<u8>) -> Vec<u8> {
+    let signature = short_signature("crossChainEpochOracle", &[ParamType::Bytes]);
+    let payload = Token::Bytes(payload);
+    let encoded = encode(&[payload]);
+    signature.into_iter().chain(encoded.into_iter()).collect()
 }

--- a/crates/xtask/src/main.rs
+++ b/crates/xtask/src/main.rs
@@ -9,7 +9,10 @@ mod message_samples;
 #[derive(clap::Parser)]
 enum Tasks {
     /// Compile and display encoded message samples
-    EncodeMessageSamples,
+    EncodeMessageSamples {
+        #[clap(short, long, action)]
+        calldata: bool,
+    },
     /// Queries the Epoch Manager for the current epoch
     CurrentEpoch {
         #[clap(short, long)]
@@ -28,7 +31,7 @@ enum Tasks {
 async fn main() -> anyhow::Result<()> {
     use Tasks::*;
     match Tasks::parse() {
-        EncodeMessageSamples => message_samples::encode()?,
+        EncodeMessageSamples { calldata } => message_samples::encode(calldata)?,
         CurrentEpoch { config_file } => {
             let config = Config::parse_from(config_file);
             contracts::current_epoch(config).await?

--- a/crates/xtask/src/message_samples.rs
+++ b/crates/xtask/src/message_samples.rs
@@ -34,7 +34,7 @@ pub fn encode() -> anyhow::Result<()> {
 
     for json_file in glob(&format!("{}/*.json", JSON_SAMPLES_DIRECTORY))? {
         let json_path = json_file?;
-        let output = cmd!(sh, "./target/debug/oracle-encoder --json-path {json_path}").read()?;
+        let output = cmd!(sh, "./target/debug/oracle-encoder {json_path}").read()?;
         let file_name = json_path.to_string_lossy();
         let sample_name = file_name.trim_end_matches(".json");
         println!("[sample: {}]\n{}\n", sample_name, output);

--- a/crates/xtask/src/message_samples.rs
+++ b/crates/xtask/src/message_samples.rs
@@ -25,16 +25,20 @@ fn compile() -> anyhow::Result<()> {
     Ok(())
 }
 
-pub fn encode() -> anyhow::Result<()> {
+pub fn encode(calldata: bool) -> anyhow::Result<()> {
+    let calldata = calldata.then(|| "--calldata");
     compile()?;
     let sh = Shell::new()?;
     cmd!(sh, "cargo build --package oracle-encoder")
         .quiet()
         .run()?;
-
     for json_file in glob(&format!("{}/*.json", JSON_SAMPLES_DIRECTORY))? {
         let json_path = json_file?;
-        let output = cmd!(sh, "./target/debug/oracle-encoder {json_path}").read()?;
+        let output = cmd!(
+            sh,
+            "./target/debug/oracle-encoder {calldata...} {json_path}"
+        )
+        .read()?;
         let file_name = json_path.to_string_lossy();
         let sample_name = file_name.trim_end_matches(".json");
         println!("[sample: {}]\n{}\n", sample_name, output);


### PR DESCRIPTION
This PR adds the `--calldata` argument to the `oracle-encoder` program, allowing it to output the calldata instead of just the payload. 