### PR TITLE
Fix empty `Encoder` network list

### DIFF
--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -222,22 +222,9 @@ impl Oracle {
         messages.push(latest_blocks_to_message(latest_blocks));
 
         let available_networks: Vec<(String, epoch_encoding::Network)> = {
-            // intersect networks from config and subgraph
-            let config_chain_ids: HashSet<&Caip2ChainId> = self
-                .config
-                .indexed_chains
-                .iter()
-                .map(|chain| &chain.id)
-                .collect();
             registered_networks
                 .into_iter()
-                .filter_map(|network| {
-                    if config_chain_ids.contains(&network.id) {
-                        Some((network.id.as_str().to_owned(), network.into()))
-                    } else {
-                        None
-                    }
-                })
+                .map(|network| (network.id.as_str().to_owned(), network.into()))
                 .collect()
         };
 

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -6,10 +6,7 @@ use crate::{
     SubgraphStateTracker,
 };
 use epoch_encoding::{self as ee, BlockPtr, Encoder, Message, CURRENT_ENCODING_VERSION};
-use std::{
-    cmp::Ordering,
-    collections::{BTreeMap, HashSet},
-};
+use std::{cmp::Ordering, collections::BTreeMap};
 use tracing::{debug, error, info, warn};
 
 /// The main application in-memory state.

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -208,11 +208,7 @@ impl Oracle {
         // `RegisterNetworks` messages.
         let networks_diff = {
             // `NetworksDiff::calculate` uses u32's but `registered_networks` has u64's
-            let networks_and_block_numbers = registered_networks
-                .iter()
-                .map(|(chain_id, network)| (chain_id.clone(), network.block_number))
-                .collect();
-            NetworksDiff::calculate(networks_and_block_numbers, self.config)
+            NetworksDiff::calculate(&registered_networks, self.config)
         };
         info!(
             created = networks_diff.insertions.len(),
@@ -235,9 +231,9 @@ impl Oracle {
                 .collect();
             registered_networks
                 .into_iter()
-                .filter_map(|(chain_id, network)| {
-                    if config_chain_ids.contains(&chain_id) {
-                        Some((chain_id.as_str().to_owned(), network))
+                .filter_map(|network| {
+                    if config_chain_ids.contains(&network.id) {
+                        Some((network.id.as_str().to_owned(), network.into()))
                     } else {
                         None
                     }
@@ -285,22 +281,9 @@ impl Oracle {
 
 fn registered_networks(
     subgraph_state: &SubgraphStateTracker<SubgraphQuery>,
-) -> Vec<(Caip2ChainId, ee::Network)> {
+) -> Vec<crate::subgraph::Network> {
     if let Ok(Some(state)) = subgraph_state.result() {
-        state
-            .1
-            .networks
-            .iter()
-            .map(|network| {
-                (
-                    network.id.clone(),
-                    epoch_encoding::Network {
-                        block_number: network.latest_block_number,
-                        block_delta: network.delta,
-                    },
-                )
-            })
-            .collect()
+        state.1.networks.to_vec()
     } else {
         // The subgraph is uninitialized, so there's no registered networks at all.
         vec![]

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -173,6 +173,7 @@ impl From<Network> for epoch_encoding::Network {
         epoch_encoding::Network {
             block_number: val.latest_block_number,
             block_delta: val.delta,
+            array_index: val.array_index,
         }
     }
 }

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -151,20 +151,30 @@ where
     }
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalState {
     pub networks: Vec<Network>,
     pub encoding_version: i64,
     pub latest_epoch_number: Option<u64>,
 }
 
-#[derive(Debug, Clone, PartialEq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Network {
     pub id: Caip2ChainId,
     pub latest_block_number: u64,
     pub acceleration: i64,
     pub delta: i64,
     pub updated_at_epoch_number: u64,
+    pub array_index: u64,
+}
+
+impl From<Network> for epoch_encoding::Network {
+    fn from(val: Network) -> Self {
+        epoch_encoding::Network {
+            block_number: val.latest_block_number,
+            block_delta: val.delta,
+        }
+    }
 }
 
 impl TryFrom<graphql::subgraph_state::SubgraphStateGlobalStateNetworks> for Network {
@@ -184,6 +194,12 @@ impl TryFrom<graphql::subgraph_state::SubgraphStateGlobalStateNetworks> for Netw
             .as_str()
             .parse()
             .map_err(|s| anyhow::anyhow!("Invalid network name: {}", s))?;
+
+        let array_index = value
+            .array_index
+            .ok_or_else(|| anyhow::anyhow!("Expected a valid array_index for Network"))?
+            as u64;
+
         let block_number_info = value.block_numbers.pop().unwrap();
 
         Ok(Network {
@@ -192,6 +208,7 @@ impl TryFrom<graphql::subgraph_state::SubgraphStateGlobalStateNetworks> for Netw
             acceleration: block_number_info.acceleration.parse()?,
             delta: block_number_info.delta.parse()?,
             updated_at_epoch_number: block_number_info.epoch_number.parse()?,
+            array_index,
         })
     }
 }


### PR DESCRIPTION
Some bugfixes:
058a1a6d1c16342db00ff6df7306eb43738fdf1a: Block numbers were being passed as network indices to the `NetworkDiff` struct .
5b65d765408a2385ff101c1c601f76d87141240d: The `Encoder` was being created with a network list different than the current Epoch Subgraph state.
a69daa52ef77be10a853d75418d1440aafe2b0b8: `Encoder::remove_network` was using the Network array indices to `swap_remove` elements from its internal network list.