### PR TITLE
docker compose: Fix hardhat config and update postgres command

### DIFF
--- a/k8s/compose/docker-compose.yml
+++ b/k8s/compose/docker-compose.yml
@@ -52,9 +52,7 @@ services:
   postgres:
     image: postgres
     user: postgres
-    command: >
-      sh -c "rm -rf /pgdata/* &&
-      postgres -cshared_preload_libraries=pg_stat_statements"
+    command: postgres -cshared_preload_libraries=pg_stat_statements
     environment:
       POSTGRES_USER: graph-node
       POSTGRES_PASSWORD: let-me-in

--- a/packages/contracts/hardhat.config.ts
+++ b/packages/contracts/hardhat.config.ts
@@ -99,7 +99,7 @@ const config: HardhatUserConfig = {
       chainId: 1337,
       loggingEnabled: false,
       gas: 1200000,
-      gasPrice: auto,
+      gasPrice: 'auto',
       blockGasLimit: 12000000,
       accounts: {
         mnemonic: 'myth like bonus scare over problem client lizard pioneer submit female collect',


### PR DESCRIPTION
There was a typo in the hardhat configuration, and the `rm /pgdata/` command was useless.

The recommended way of using fresh volumes without creating new containers is stated in the related #166 PR.

