### PR TITLE
Basic Prometheus monitoring 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3,185 +3,6 @@
 version = 3
 
 [[package]]
-name = "actix-codec"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "57a7559404a7f3573127aab53c08ce37a6c6a315c374a31070f3c91cd1b4a7fe"
-dependencies = [
- "bitflags",
- "bytes",
- "futures-core",
- "futures-sink",
- "log",
- "memchr",
- "pin-project-lite",
- "tokio",
- "tokio-util 0.7.3",
-]
-
-[[package]]
-name = "actix-http"
-version = "3.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6f9ffb6db08c1c3a1f4aef540f1a63193adc73c4fbd40b75a95fc8c5258f6e51"
-dependencies = [
- "actix-codec",
- "actix-rt",
- "actix-service",
- "actix-utils",
- "ahash",
- "base64",
- "bitflags",
- "brotli",
- "bytes",
- "bytestring",
- "derive_more",
- "encoding_rs",
- "flate2",
- "futures-core",
- "h2",
- "http",
- "httparse",
- "httpdate",
- "itoa",
- "language-tags",
- "local-channel",
- "mime",
- "percent-encoding",
- "pin-project-lite",
- "rand",
- "sha1",
- "smallvec",
- "tracing",
- "zstd",
-]
-
-[[package]]
-name = "actix-macros"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "465a6172cf69b960917811022d8f29bc0b7fa1398bc4f78b3c466673db1213b6"
-dependencies = [
- "quote",
- "syn",
-]
-
-[[package]]
-name = "actix-router"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb60846b52c118f2f04a56cc90880a274271c489b2498623d58176f8ca21fa80"
-dependencies = [
- "bytestring",
- "firestorm",
- "http",
- "log",
- "regex",
- "serde",
-]
-
-[[package]]
-name = "actix-rt"
-version = "2.7.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ea16c295198e958ef31930a6ef37d0fb64e9ca3b6116e6b93a8bdae96ee1000"
-dependencies = [
- "futures-core",
- "tokio",
-]
-
-[[package]]
-name = "actix-server"
-version = "2.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0da34f8e659ea1b077bb4637948b815cd3768ad5a188fdcd74ff4d84240cd824"
-dependencies = [
- "actix-rt",
- "actix-service",
- "actix-utils",
- "futures-core",
- "futures-util",
- "mio",
- "num_cpus",
- "socket2",
- "tokio",
- "tracing",
-]
-
-[[package]]
-name = "actix-service"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b894941f818cfdc7ccc4b9e60fa7e53b5042a2e8567270f9147d5591893373a"
-dependencies = [
- "futures-core",
- "paste",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-utils"
-version = "3.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e491cbaac2e7fc788dfff99ff48ef317e23b3cf63dbaf7aaab6418f40f92aa94"
-dependencies = [
- "local-waker",
- "pin-project-lite",
-]
-
-[[package]]
-name = "actix-web"
-version = "4.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a27e8fe9ba4ae613c21f677c2cfaf0696c3744030c6f485b34634e502d6bb379"
-dependencies = [
- "actix-codec",
- "actix-http",
- "actix-macros",
- "actix-router",
- "actix-rt",
- "actix-server",
- "actix-service",
- "actix-utils",
- "actix-web-codegen",
- "ahash",
- "bytes",
- "bytestring",
- "cfg-if",
- "cookie",
- "derive_more",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "itoa",
- "language-tags",
- "log",
- "mime",
- "once_cell",
- "pin-project-lite",
- "regex",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "socket2",
- "time",
- "url",
-]
-
-[[package]]
-name = "actix-web-codegen"
-version = "4.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5f270541caec49c15673b0af0e9a00143421ad4f118d2df7edcb68b627632f56"
-dependencies = [
- "actix-router",
- "proc-macro2",
- "quote",
- "syn",
-]
-
-[[package]]
 name = "addr2line"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -197,38 +18,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f26201604c87b1e01bd3d98f8d5d9a8fcbb815e8cedb41ffccbeb4bf593a35fe"
 
 [[package]]
-name = "ahash"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fcb51a0695d8f838b1ee009b3fbf66bda078cd64590202a864a8f3e8c4315c47"
-dependencies = [
- "getrandom",
- "once_cell",
- "version_check",
-]
-
-[[package]]
 name = "aho-corasick"
 version = "0.7.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1e37cfd5e7657ada45f742d6e99ca5788580b5c529dc78faf11ece6dc702656f"
 dependencies = [
  "memchr",
-]
-
-[[package]]
-name = "alloc-no-stdlib"
-version = "2.0.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "35ef4730490ad1c4eae5c4325b2a95f521d023e5c885853ff7aca0a6a1631db3"
-
-[[package]]
-name = "alloc-stdlib"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "697ed7edc0f1711de49ce108c541623a0af97c6c60b2f6e2b65229847ac843c2"
-dependencies = [
- "alloc-no-stdlib",
 ]
 
 [[package]]
@@ -374,7 +169,6 @@ dependencies = [
 name = "block-oracle"
 version = "0.1.0"
 dependencies = [
- "actix-web",
  "anyhow",
  "async-trait",
  "backoff",
@@ -410,27 +204,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8d696c370c750c948ada61c69a0ee2cbbb9c50b1019ddb86d9317157a99c2cae"
 
 [[package]]
-name = "brotli"
-version = "3.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a1a0b1dbcc8ae29329621f8d4f0d835787c1c38bb1401979b49d13b0b305ff68"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
- "brotli-decompressor",
-]
-
-[[package]]
-name = "brotli-decompressor"
-version = "2.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "59ad2d4653bf5ca36ae797b1f4bb4dbddb60ce49ca4aed8a2ce4829f60425b80"
-dependencies = [
- "alloc-no-stdlib",
- "alloc-stdlib",
-]
-
-[[package]]
 name = "bumpalo"
 version = "3.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -455,22 +228,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f0b3de4a0c5e67e16066a0715723abd91edc2f9001d09c46e1dca929351e130e"
 
 [[package]]
-name = "bytestring"
-version = "1.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "86b6a75fd3048808ef06af5cd79712be8111960adaf89d90250974b38fc3928a"
-dependencies = [
- "bytes",
-]
-
-[[package]]
 name = "cc"
 version = "1.0.73"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2fff2a6927b3bb87f9595d67196a70493f627687a71d87a0d692242c33f58c11"
-dependencies = [
- "jobserver",
-]
 
 [[package]]
 name = "cfg-if"
@@ -537,17 +298,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6245d59a3e82a7fc217c5828a6692dbc6dfb63a0c8c90495621f7b9d79704a0e"
 
 [[package]]
-name = "cookie"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "94d4706de1b0fa5b132270cddffa8585166037822e260a944fe161acd137ca05"
-dependencies = [
- "percent-encoding",
- "time",
- "version_check",
-]
-
-[[package]]
 name = "core-foundation"
 version = "0.9.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -570,15 +320,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59a6001667ab124aebae2a495118e11d30984c3a653e99d86d58971708cf5e4b"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "crc32fast"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b540bd8bc810d3885c6ea91e2018302f68baba2129ab3e88f32389ee9370880d"
-dependencies = [
- "cfg-if",
 ]
 
 [[package]]
@@ -818,12 +559,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "firestorm"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c5f6c2c942da57e2aaaa84b8a521489486f14e75e7fa91dab70aba913975f98"
-
-[[package]]
 name = "fixed-hash"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -833,16 +568,6 @@ dependencies = [
  "rand",
  "rustc-hex",
  "static_assertions",
-]
-
-[[package]]
-name = "flate2"
-version = "1.0.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f82b0f4c27ad9f8bfd1f3208d882da2b09c301bc1c828fd3a00d0216d2fbbff6"
-dependencies = [
- "crc32fast",
- "miniz_oxide",
 ]
 
 [[package]]
@@ -1330,15 +1055,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "112c678d4050afce233f4f2852bb2eb519230b3cf12f33585275537d7e41578d"
 
 [[package]]
-name = "jobserver"
-version = "0.1.24"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "af25a77299a7f711a01975c35a6a424eb6862092cc2d6c72c4ed6cbc56dfc1fa"
-dependencies = [
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.58"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1369,12 +1085,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f9b7d56ba4a8344d6be9729995e6b06f928af29998cdf79fe390cbf6b1fee838"
 
 [[package]]
-name = "language-tags"
-version = "0.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d4345964bb142484797b161f473a503a434de77149dd8c7427788c6e13379388"
-
-[[package]]
 name = "lazy_static"
 version = "1.4.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1385,24 +1095,6 @@ name = "libc"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "349d5a591cd28b49e1d1037471617a32ddcda5731b99419008085f72d5a53836"
-
-[[package]]
-name = "local-channel"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7f303ec0e94c6c54447f84f3b0ef7af769858a9c4ef56ef2a986d3dcd4c3fc9c"
-dependencies = [
- "futures-core",
- "futures-sink",
- "futures-util",
- "local-waker",
-]
-
-[[package]]
-name = "local-waker"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e34f76eb3611940e0e7d53a9aaa4e6a3151f69541a282fd0dad5571420c53ff1"
 
 [[package]]
 name = "lock_api"
@@ -1513,15 +1205,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "19e64526ebdee182341572e50e9ad03965aa510cd94427a4549448f285e957a1"
 dependencies = [
  "hermit-abi",
- "libc",
-]
-
-[[package]]
-name = "num_threads"
-version = "0.1.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
-dependencies = [
  "libc",
 ]
 
@@ -1683,12 +1366,6 @@ dependencies = [
  "smallvec",
  "windows-sys",
 ]
-
-[[package]]
-name = "paste"
-version = "1.0.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0c520e05135d6e763148b6426a837e239041653ba7becd2e538c076c738025fc"
 
 [[package]]
 name = "percent-encoding"
@@ -2152,17 +1829,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "sha1"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c77f4e7f65455545c2153c1253d25056825e77ee2533f0e41deb65a93a34852f"
-dependencies = [
- "cfg-if",
- "cpufeatures",
- "digest 0.10.3",
-]
-
-[[package]]
 name = "sha3"
 version = "0.9.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2342,24 +2008,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "time"
-version = "0.3.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "72c91f41dcb2f096c05f0873d667dceec1087ce5bcf984ec8ffb19acddbb3217"
-dependencies = [
- "itoa",
- "libc",
- "num_threads",
- "time-macros",
-]
-
-[[package]]
-name = "time-macros"
-version = "0.2.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42657b1a6f4d817cda8e7a0ace261fe0cc946cf3a80314390b22cc61ae080792"
-
-[[package]]
 name = "tiny-keccak"
 version = "2.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2487,7 +2135,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a400e31aa60b9d44a52a8ee0343b5b18566b03a8321e0d321f695cf56e940160"
 dependencies = [
  "cfg-if",
- "log",
  "pin-project-lite",
  "tracing-attributes",
  "tracing-core",
@@ -2914,33 +2561,4 @@ dependencies = [
  "url",
  "web3",
  "xshell",
-]
-
-[[package]]
-name = "zstd"
-version = "0.11.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20cc960326ece64f010d2d2107537f26dc589a6573a316bd5b1dba685fa5fde4"
-dependencies = [
- "zstd-safe",
-]
-
-[[package]]
-name = "zstd-safe"
-version = "5.0.2+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d2a5585e04f9eea4b2a3d1eca508c4dee9592a89ef6f450c11719da0726f4db"
-dependencies = [
- "libc",
- "zstd-sys",
-]
-
-[[package]]
-name = "zstd-sys"
-version = "2.0.1+zstd.1.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fd07cbbc53846d9145dbffdf6dd09a7a0aa52be46741825f5c97bdd4f73f12b"
-dependencies = [
- "cc",
- "libc",
 ]

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -12,7 +12,7 @@ futures = "0.3.21"
 jsonrpc-core = "18.0.0"
 graphql_client = "0.10.0"
 lazy_static = "1"
-prometheus = "0.13.0"
+prometheus = "0.13"
 reqwest = "0.11.10"
 secp256k1 = "0.21"
 serde = { version = "1.0.136", features = ["derive"] }

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -4,7 +4,6 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-actix-web = "4"
 backoff = { version = "0.4.0", features = ["tokio"] }
 clap = { version = "3", features = ["derive"] }
 ctrlc = "3.2.1"
@@ -29,6 +28,7 @@ hex = "0.4.3"
 anyhow = "1.0.57"
 async-trait = "0.1.53"
 itertools = "0.10.3"
+hyper = { version = "0.14", features = ["server"] }
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -50,6 +50,7 @@ pub struct Config {
     pub freshness_threshold: u64,
     pub protocol_chain: ProtocolChain,
     pub retry_strategy_max_wait_time: Duration,
+    pub metrics_port: u16,
 }
 
 impl Config {
@@ -97,6 +98,7 @@ impl Config {
                     config_file.protocol_chain.polling_interval_in_seconds,
                 ),
             },
+            metrics_port: config_file.metrics_port,
         }
     }
 }
@@ -135,6 +137,8 @@ struct ConfigFile {
     log_level: FromStrWrapper<LevelFilter>,
     protocol_chain: SerdeProtocolChain,
     indexed_chains: HashMap<Caip2ChainId, EitherLiteralOrEnvVar<Url>>,
+    #[serde(default = "serde_defaults::metrics_port")]
+    metrics_port: u16,
 }
 
 impl ConfigFile {
@@ -228,6 +232,10 @@ mod serde_defaults {
 
     pub fn transaction_confirmation_count() -> usize {
         0
+    }
+
+    pub fn metrics_port() -> u16 {
+        9090
     }
 }
 

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -1,3 +1,4 @@
+use crate::metrics::METRICS;
 use anyhow::Context;
 use secp256k1::SecretKey;
 use tracing::{debug, info, trace};
@@ -50,6 +51,7 @@ where
             .await?;
         let current_epoch = epoch_number.as_u64();
         debug!("Epoch Manager is at epoch {current_epoch}");
+        METRICS.set_current_epoch("manager", current_epoch as i64);
         Ok(current_epoch)
     }
 

--- a/crates/oracle/src/lib.rs
+++ b/crates/oracle/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod config;
 pub mod contracts;
+pub mod metrics;
 pub mod models;

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -12,8 +12,9 @@ mod subgraph;
 pub use crate::ctrlc::CtrlcHandler;
 pub use config::Config;
 pub use error_handling::{MainLoopFlow, OracleControlFlow};
+use futures::TryFutureExt;
 pub use jrpc_utils::JrpcExpBackoff;
-pub use metrics::Metrics;
+pub use metrics::{metrics_server, Metrics};
 pub use models::{Caip2ChainId, JrpcProviderForChain};
 pub use networks_diff::NetworksDiff;
 pub use oracle::Oracle;
@@ -29,6 +30,14 @@ lazy_static! {
     pub static ref CONFIG: Config = Config::parse();
     pub static ref METRICS: Metrics = Metrics::default();
     pub static ref CTRLC_HANDLER: CtrlcHandler = CtrlcHandler::init();
+}
+
+#[derive(Debug, thiserror::Error)]
+enum ApplicationError {
+    #[error(transparent)]
+    Oracle(Error),
+    #[error("The metrics server crashed")]
+    Metrics(#[from] hyper::Error),
 }
 
 #[derive(Debug, thiserror::Error)]
@@ -72,7 +81,7 @@ impl MainLoopFlow for Error {
 }
 
 #[tokio::main]
-async fn main() -> Result<(), Error> {
+async fn main() -> Result<(), ApplicationError> {
     // Immediately dereference some constants to trigger `lazy_static`
     // initialization.
     let _ = &*CONFIG;
@@ -82,6 +91,13 @@ async fn main() -> Result<(), Error> {
     init_logging(CONFIG.log_level);
     info!(log_level = %CONFIG.log_level, "The block oracle is starting.");
 
+    let metrics_server = metrics_server(&METRICS).map_err(ApplicationError::Metrics);
+    let oracle = run_oracle().map_err(ApplicationError::Oracle);
+    tokio::try_join!(metrics_server, oracle)?;
+    Ok(())
+}
+
+async fn run_oracle() -> Result<(), Error> {
     let mut oracle = Oracle::new(&*CONFIG);
     info!("Entering the main polling loop. Press CTRL+C to stop.");
 
@@ -99,7 +115,6 @@ async fn main() -> Result<(), Error> {
         );
         tokio::time::sleep(CONFIG.protocol_chain.polling_interval).await;
     }
-
     Ok(())
 }
 

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -90,7 +90,8 @@ async fn main() -> Result<(), ApplicationError> {
     init_logging(CONFIG.log_level);
     info!(log_level = %CONFIG.log_level, "The block oracle is starting.");
 
-    let metrics_server = metrics_server(&METRICS).map_err(ApplicationError::Metrics);
+    let metrics_server =
+        metrics_server(&METRICS, CONFIG.metrics_port).map_err(ApplicationError::Metrics);
     let oracle = oracle_task().map_err(ApplicationError::Oracle);
     tokio::try_join!(metrics_server, oracle)?;
     Ok(())

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -14,7 +14,7 @@ pub use config::Config;
 pub use error_handling::{MainLoopFlow, OracleControlFlow};
 use futures::TryFutureExt;
 pub use jrpc_utils::JrpcExpBackoff;
-pub use metrics::{metrics_server, Metrics};
+pub use metrics::{server::metrics_server, Metrics};
 pub use models::{Caip2ChainId, JrpcProviderForChain};
 pub use networks_diff::NetworksDiff;
 pub use oracle::Oracle;

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -28,7 +28,7 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 lazy_static! {
     pub static ref CONFIG: Config = Config::parse();
-    pub static ref METRICS: Metrics = Metrics::default();
+    pub static ref METRICS: Metrics = Metrics::new().expect("failed to create Metrics");
     pub static ref CTRLC_HANDLER: CtrlcHandler = CtrlcHandler::init();
 }
 

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -92,12 +92,12 @@ async fn main() -> Result<(), ApplicationError> {
     info!(log_level = %CONFIG.log_level, "The block oracle is starting.");
 
     let metrics_server = metrics_server(&METRICS).map_err(ApplicationError::Metrics);
-    let oracle = run_oracle().map_err(ApplicationError::Oracle);
+    let oracle = oracle_task().map_err(ApplicationError::Oracle);
     tokio::try_join!(metrics_server, oracle)?;
     Ok(())
 }
 
-async fn run_oracle() -> Result<(), Error> {
+async fn oracle_task() -> Result<(), Error> {
     let mut oracle = Oracle::new(&*CONFIG);
     info!("Entering the main polling loop. Press CTRL+C to stop.");
 

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -14,7 +14,7 @@ pub use config::Config;
 pub use error_handling::{MainLoopFlow, OracleControlFlow};
 use futures::TryFutureExt;
 pub use jrpc_utils::JrpcExpBackoff;
-pub use metrics::{server::metrics_server, Metrics};
+pub use metrics::{server::metrics_server, Metrics, METRICS};
 pub use models::{Caip2ChainId, JrpcProviderForChain};
 pub use networks_diff::NetworksDiff;
 pub use oracle::Oracle;
@@ -28,7 +28,6 @@ use tracing_subscriber::{fmt, prelude::*, EnvFilter};
 
 lazy_static! {
     pub static ref CONFIG: Config = Config::parse();
-    pub static ref METRICS: Metrics = Metrics::new().expect("failed to create Metrics");
     pub static ref CTRLC_HANDLER: CtrlcHandler = CtrlcHandler::init();
 }
 

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -1,3 +1,10 @@
+use std::{convert::Infallible, net::SocketAddr};
+
+use futures::Future;
+use hyper::{
+    service::{make_service_fn, service_fn},
+    Body, Request, Response, Server,
+};
 use prometheus::{Encoder, HistogramOpts, HistogramVec, Registry, TextEncoder};
 
 #[derive(Debug, Clone)]
@@ -38,4 +45,17 @@ impl Default for Metrics {
             retries_by_jsonrpc_provider,
         }
     }
+}
+
+async fn handle(_req: Request<Body>) -> Result<Response<Body>, Infallible> {
+    Ok(Response::new(Body::from("Hello World")))
+}
+
+pub fn metrics_server(
+    _metrics: &'static Metrics,
+) -> impl Future<Output = Result<(), hyper::Error>> {
+    // TODO: make this configurable
+    let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+    let make_service = make_service_fn(|_conn| async { Ok::<_, Infallible>(service_fn(handle)) });
+    Server::bind(&addr).serve(make_service)
 }

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -1,4 +1,7 @@
-use prometheus::{Encoder, HistogramOpts, HistogramVec, IntGaugeVec, Registry, TextEncoder};
+use prometheus::{
+    register_histogram_vec_with_registry, register_int_gauge_vec_with_registry, Encoder,
+    HistogramVec, IntGaugeVec, Registry, TextEncoder,
+};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {
@@ -21,23 +24,21 @@ impl Default for Metrics {
     fn default() -> Self {
         let registry = Registry::new();
 
-        let retries_by_jsonrpc_provider = HistogramVec::new(
-            HistogramOpts::new(
-                "retries_by_jsonrpc_provider",
-                "Number of JSON-RPC request retries.",
-            ),
-            &["jsonrpc_provider"],
+        let retries_by_jsonrpc_provider = register_histogram_vec_with_registry!(
+            "retries_by_jsonrpc_provider",
+            "Number of JSON-RPC request retries.",
+            &["provider"],
+            registry
         )
-        .expect("failed to create metric");
-        registry
-            .register(Box::new(retries_by_jsonrpc_provider.clone()))
-            .expect("failed to register Prometheus metric");
+        .unwrap();
 
-        let current_epoch = IntGaugeVec::new("current_epoch", "Epoch Manager Current Epoch")
-            .expect("failed to create metric");
-        registry
-            .register(Box::new(current_epoch.clone()))
-            .expect("failed to register metric");
+        let current_epoch = register_int_gauge_vec_with_registry!(
+            "current_epoch",
+            "Current Epoch",
+            &["manager", "subgraph"],
+            registry
+        )
+        .unwrap();
 
         Self {
             registry,

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -11,7 +11,7 @@ lazy_static! {
 #[derive(Debug, Clone)]
 pub struct Metrics {
     registry: Registry,
-    retries_by_jsonrpc_provider: HistogramVec,
+    _retries_by_jsonrpc_provider: HistogramVec,
     current_epoch: IntGaugeVec,
 }
 
@@ -35,7 +35,7 @@ impl Metrics {
 
         Ok(Self {
             registry,
-            retries_by_jsonrpc_provider,
+            _retries_by_jsonrpc_provider: retries_by_jsonrpc_provider,
             current_epoch,
         })
     }

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -1,7 +1,12 @@
+use lazy_static::lazy_static;
 use prometheus::{
     register_histogram_vec_with_registry, register_int_gauge_vec_with_registry, Encoder,
     HistogramVec, IntGaugeVec, Registry, TextEncoder,
 };
+
+lazy_static! {
+    pub static ref METRICS: Metrics = Metrics::new().expect("failed to create Metrics");
+}
 
 #[derive(Debug, Clone)]
 pub struct Metrics {

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -1,4 +1,4 @@
-use prometheus::*;
+use prometheus::{Encoder, HistogramOpts, HistogramVec, Registry, TextEncoder};
 
 #[derive(Debug, Clone)]
 pub struct Metrics {

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -24,7 +24,7 @@ impl Metrics {
         let current_epoch = register_int_gauge_vec_with_registry!(
             "current_epoch",
             "Current Epoch",
-            &["manager", "subgraph"],
+            &["source"],
             registry
         )?;
 

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -47,6 +47,13 @@ impl Metrics {
             .expect("failed to encode gathered Prometheus metrics");
         buffer
     }
+
+    pub fn set_current_epoch(&self, label: &str, current_epoch: i64) {
+        self.current_epoch
+            .get_metric_with_label_values(&[label])
+            .unwrap()
+            .set(current_epoch as i64);
+    }
 }
 
 pub mod server {

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -64,6 +64,7 @@ pub mod server {
         Body, Request, Response, Server,
     };
     use std::{convert::Infallible, net::SocketAddr};
+    use tracing::info;
 
     async fn handle_metrics_server_request(
         _req: Request<Body>,
@@ -82,12 +83,13 @@ pub mod server {
         port: u16,
     ) -> impl Future<Output = Result<(), hyper::Error>> {
         // TODO: make this configurable
-        let addr = SocketAddr::from(([127, 0, 0, 1], port));
+        let addr = SocketAddr::from(([0, 0, 0, 0], port));
         let make_service = make_service_fn(move |_conn| async move {
             Ok::<_, Infallible>(service_fn(move |req| {
                 handle_metrics_server_request(req, metrics)
             }))
         });
+        info!("Starting metrics server at port {port}");
         Server::bind(&addr).serve(make_service)
     }
 }

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -79,9 +79,10 @@ pub mod server {
 
     pub fn metrics_server(
         metrics: &'static Metrics,
+        port: u16,
     ) -> impl Future<Output = Result<(), hyper::Error>> {
         // TODO: make this configurable
-        let addr = SocketAddr::from(([127, 0, 0, 1], 3000));
+        let addr = SocketAddr::from(([127, 0, 0, 1], port));
         let make_service = make_service_fn(move |_conn| async move {
             Ok::<_, Infallible>(service_fn(move |req| {
                 handle_metrics_server_request(req, metrics)

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -2,6 +2,7 @@ use crate::{
     contracts::Contracts,
     hex_string,
     jrpc_utils::{get_latest_block, get_latest_blocks},
+    metrics::METRICS,
     Caip2ChainId, Config, Error, JrpcExpBackoff, JrpcProviderForChain, NetworksDiff, SubgraphQuery,
     SubgraphStateTracker,
 };
@@ -142,6 +143,7 @@ impl Oracle {
             }
         };
         debug!("Subgraph is at epoch {subgraph_latest_epoch}");
+        METRICS.set_current_epoch("subgraph", subgraph_latest_epoch as i64);
         let manager_current_epoch = self.contracts.query_current_epoch().await?;
         match subgraph_latest_epoch.cmp(&manager_current_epoch) {
             Ordering::Less => Ok(PreviousEpoch {

--- a/k8s/compose/docker-compose.yml
+++ b/k8s/compose/docker-compose.yml
@@ -12,6 +12,8 @@ services:
       DATA_EDGE_CONTRACT_ADDRESS: 'e78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab'
       EPOCH_MANAGER_CONTRACT_ADDRESS: 'd833215cbcc3f914bd1c9ece3ee7bf8b14f841bb'
       PROTOCOL_CHAIN_JRPC_URL: "http://hardhat:8545"
+    ports:
+      - 9090
     volumes:
       - ./config.toml:/app/config.toml
     depends_on:
@@ -92,3 +94,10 @@ services:
     depends_on:
       hardhat:
         condition: service_healthy
+
+  prometheus:
+    image: bitnami/prometheus
+    volumes:
+      - ./prometheus/config.yaml:/opt/bitnami/prometheus/conf/prometheus.yml
+    ports:
+      - "9092:9090"

--- a/k8s/compose/prometheus/config.yaml
+++ b/k8s/compose/prometheus/config.yaml
@@ -1,0 +1,10 @@
+global:
+  scrape_interval: 10s
+
+scrape_configs:
+  - job_name: prometheus
+    static_configs:
+      - targets: ['localhost:9090']
+  - job_name: block-oracle
+    static_configs:
+      - targets: ["block-oracle:9090"]


### PR DESCRIPTION
This PR lays out the foundation for Prometheus instrumentation:

1. a `&'static` metrics registry _(done mainly by @neysofu in previous commits)_.
2. a `hyper` HTTP server that serves Prometheus gathered metrics, running concurrent to Oracle's main loop.
3. a POC metric + instrumentation for tracking the current epoch, both at the Epoch Manager contract and the Epoch Subgraph.
4. a docker-compose entry and configuration for a `prometheus` service.

