### PR TITLE
Don't send `RegisterNetworks` msg, fail on indexed chain diff

### DIFF
--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -56,8 +56,10 @@ pub enum Error {
     EpochManagerCallFailed(#[from] web3::contract::Error),
     #[error("Epoch Manager latest epoch ({manager}) is behind Epoch Subgraph's ({subgraph})")]
     EpochManagerBehindSubgraph { manager: u64, subgraph: u64 },
-    #[error("The subgraph hasn't indexed all relevant transactions yet.")]
+    #[error("The subgraph hasn't indexed all relevant transactions yet")]
     SubgraphNotFresh,
+    #[error("There is a difference between the configured and registered indexed chains")]
+    MalconfiguredIndexedChains(NetworksDiff),
 }
 
 impl MainLoopFlow for Error {
@@ -75,6 +77,8 @@ impl MainLoopFlow for Error {
 
             // TODO: Put those variants under the `SubgraphQueryError` enum
             SubgraphNotFresh => OracleControlFlow::Continue(Some(Duration::from_secs(30))),
+
+            MalconfiguredIndexedChains(_) => OracleControlFlow::Break(()),
         }
     }
 }

--- a/crates/oracle/src/networks_diff.rs
+++ b/crates/oracle/src/networks_diff.rs
@@ -30,4 +30,8 @@ impl NetworksDiff {
             insertions,
         }
     }
+
+    pub(crate) fn is_empty(&self) -> bool {
+        self.deletions.is_empty() && self.insertions.is_empty()
+    }
 }

--- a/crates/oracle/src/oracle.rs
+++ b/crates/oracle/src/oracle.rs
@@ -205,17 +205,15 @@ impl Oracle {
 
         // First, we need to make sure that there are no pending
         // `RegisterNetworks` messages.
-        let networks_diff = {
-            // `NetworksDiff::calculate` uses u32's but `registered_networks` has u64's
-            NetworksDiff::calculate(&registered_networks, self.config)
-        };
+        let networks_diff = { NetworksDiff::calculate(&registered_networks, self.config) };
         info!(
             created = networks_diff.insertions.len(),
             deleted = networks_diff.deletions.len(),
             "Performed indexed chain diffing."
         );
-        if let Some(msg) = networks_diff_to_message(&networks_diff) {
-            messages.push(msg);
+
+        if !networks_diff.is_empty() {
+            return Err(Error::MalconfiguredIndexedChains(networks_diff));
         }
 
         messages.push(latest_blocks_to_message(latest_blocks));
@@ -283,17 +281,6 @@ fn latest_blocks_to_message(latest_blocks: BTreeMap<Caip2ChainId, BlockPtr>) -> 
             .map(|(chain_id, block_ptr)| (chain_id.as_str().to_owned(), block_ptr))
             .collect(),
     )
-}
-
-fn networks_diff_to_message(diff: &NetworksDiff) -> Option<ee::Message> {
-    if diff.deletions.is_empty() && diff.insertions.is_empty() {
-        None
-    } else {
-        Some(ee::Message::RegisterNetworks {
-            remove: diff.deletions.iter().copied().collect(),
-            add: diff.insertions.iter().map(ToString::to_string).collect(),
-        })
-    }
 }
 
 mod freshness {


### PR DESCRIPTION
Makes the Oracle not send a `RegisterNetworks` message in the advent of a new epoch.

Diffing is still performed because a configuration error is returned if there are any differences between the configured and registered networks.

Fixes #190.

