### PR TITLE
feat: wait for transaction confirmation

### DIFF
--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -47,6 +47,7 @@ pub struct Config {
     pub protocol_chain: ProtocolChain,
     pub retry_strategy_max_wait_time: Duration,
     pub metrics_port: u16,
+    pub transaction_confirmation_count: usize,
 }
 
 impl Config {
@@ -89,6 +90,7 @@ impl Config {
                 ),
             },
             metrics_port: config_file.metrics_port,
+            transaction_confirmation_count: config_file.transaction_confirmation_count,
         }
     }
 }
@@ -110,10 +112,8 @@ struct ConfigFile {
     freshness_threshold: u64,
     #[serde(default = "serde_defaults::web3_transport_retry_max_wait_time_in_seconds")]
     web3_transport_retry_max_wait_time_in_seconds: u64,
-    #[serde(default = "serde_defaults::transaction_confirmation_poll_interval_in_seconds")]
-    _transaction_confirmation_poll_interval_in_seconds: u64,
     #[serde(default = "serde_defaults::transaction_confirmation_count")]
-    _transaction_confirmation_count: usize,
+    transaction_confirmation_count: usize,
     #[serde(default = "serde_defaults::log_level")]
     log_level: FromStrWrapper<LevelFilter>,
     protocol_chain: SerdeProtocolChain,
@@ -186,7 +186,6 @@ mod serde_utils {
 
 /// These should be expressed as constants once
 /// https://github.com/serde-rs/serde/issues/368 is fixed.
-#[allow(unused)]
 mod serde_defaults {
     use super::serde_utils::FromStrWrapper;
     use tracing_subscriber::filter::LevelFilter;
@@ -207,12 +206,8 @@ mod serde_defaults {
         60
     }
 
-    pub fn transaction_confirmation_poll_interval_in_seconds() -> u64 {
-        5
-    }
-
     pub fn transaction_confirmation_count() -> usize {
-        0
+        5
     }
 
     pub fn metrics_port() -> u16 {

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -106,5 +106,6 @@ fn init_contracts(config: Config) -> anyhow::Result<Contracts<Http>> {
         &protocol_chain.web3.eth(),
         config.data_edge_address,
         config.epoch_manager_address,
+        config.transaction_confirmation_count,
     )
 }

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -42,6 +42,7 @@ impl Oracle {
             &protocol_chain.web3.eth(),
             config.data_edge_address,
             config.epoch_manager_address,
+            config.transaction_confirmation_count,
         )
         .expect("Failed to initialize Block Oracle's required contracts");
 
@@ -177,14 +178,14 @@ impl Oracle {
             .collect();
 
         let payload = set_block_numbers_for_next_epoch(subgraph_state, latest_blocks);
-        let tx_hash = self
+        let transaction_receipt = self
             .contracts
             .submit_call(payload, &self.config.owner_private_key)
             .await
             .map_err(Error::CantSubmitTx)?;
         METRICS.set_last_sent_message();
         info!(
-            tx_hash = tx_hash.to_string().as_str(),
+            tx_hash = transaction_receipt.transaction_hash.to_string().as_str(),
             "Contract call submitted successfully."
         );
 


### PR DESCRIPTION
This PR introduces a minimal transact management strategy, which is waiting for transaction confirmation within a configurable number of blocks.