### PR TITLE
Transaction Monitoring

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -174,6 +174,7 @@ dependencies = [
  "backoff",
  "clap",
  "ctrlc",
+ "either",
  "epoch-encoding",
  "ethabi 17.2.0",
  "futures",
@@ -431,9 +432,9 @@ dependencies = [
 
 [[package]]
 name = "either"
-version = "1.7.0"
+version = "1.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3f107b87b6afc2a64fd13cac55fe06d6c8859f12d4b14cbcdd2c67d0976781be"
+checksum = "90e5c1c8368803113bf0c9584fc495a58b86dc8a29edbf8fe877d21d9507e797"
 
 [[package]]
 name = "encoding_rs"

--- a/crates/oracle/Cargo.toml
+++ b/crates/oracle/Cargo.toml
@@ -33,6 +33,7 @@ tracing-subscriber = { version = "0.3.11", features = ["env-filter"] }
 url = { version = "2.2.2", features = ["serde"] }
 web3 = { version = "0.18.0", features = ["signing"] }
 warp = "0.3"
+either = "1.8.0"
 
 [dev-dependencies]
 hyper = { version = "0.14", features = ["full"] }

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -45,6 +45,35 @@ pub struct TransactionMonitoringOptions {
     /// Gas price percentual increase
     #[serde(default = "serde_defaults::transaction_monitoring_gas_percentual_increase")]
     pub gas_percentual_increase: u32,
+    /// How much time to wait between querying the JSON RPC provider for confirmations
+    #[serde(default = "serde_defaults::transaction_monitoring_poll_interval_in_seconds")]
+    pub poll_interval_in_seconds: u64,
+    /// How many confirmations to wait for
+    #[serde(default = "serde_defaults::transaction_monitoring_confirmations")]
+    pub confirmations: usize,
+    #[serde(default)]
+    pub gas_limit: u64,
+    #[serde(default)]
+    pub max_fee_per_gas: Option<u64>,
+    #[serde(default)]
+    pub max_priority_fee_per_gas: Option<u64>,
+}
+
+impl Default for TransactionMonitoringOptions {
+    fn default() -> Self {
+        use serde_defaults::*;
+        Self {
+            confirmation_timeout_in_seconds: transaction_monitoring_confirmation_timeout_in_seconds(
+            ),
+            max_retries: transaction_monitoring_max_retries(),
+            gas_percentual_increase: transaction_monitoring_gas_percentual_increase(),
+            poll_interval_in_seconds: transaction_monitoring_poll_interval_in_seconds(),
+            confirmations: transaction_monitoring_confirmations(),
+            gas_limit: 0,
+            max_fee_per_gas: None,
+            max_priority_fee_per_gas: None,
+        }
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -132,7 +161,7 @@ struct ConfigFile {
     indexed_chains: HashMap<Caip2ChainId, EitherLiteralOrEnvVar<Url>>,
     #[serde(default = "serde_defaults::metrics_port")]
     metrics_port: u16,
-    #[serde(default = "serde_defaults::transaction_monitoring_options")]
+    #[serde(default)]
     transaction_monitoring_options: TransactionMonitoringOptions,
 }
 
@@ -201,7 +230,7 @@ mod serde_utils {
 /// These should be expressed as constants once
 /// https://github.com/serde-rs/serde/issues/368 is fixed.
 mod serde_defaults {
-    use super::{serde_utils::FromStrWrapper, TransactionMonitoringOptions};
+    use super::serde_utils::FromStrWrapper;
     use tracing_subscriber::filter::LevelFilter;
 
     pub fn log_level() -> FromStrWrapper<LevelFilter> {
@@ -223,6 +252,7 @@ mod serde_defaults {
     pub fn transaction_monitoring_confirmation_timeout_in_seconds() -> u64 {
         120
     }
+
     pub fn transaction_monitoring_max_retries() -> u32 {
         10
     }
@@ -231,17 +261,16 @@ mod serde_defaults {
         50 // 50%
     }
 
-    pub fn metrics_port() -> u16 {
-        9090
+    pub fn transaction_monitoring_poll_interval_in_seconds() -> u64 {
+        5
     }
 
-    pub fn transaction_monitoring_options() -> TransactionMonitoringOptions {
-        TransactionMonitoringOptions {
-            confirmation_timeout_in_seconds: transaction_monitoring_confirmation_timeout_in_seconds(
-            ),
-            max_retries: transaction_monitoring_max_retries(),
-            gas_percentual_increase: transaction_monitoring_gas_percentual_increase(),
-        }
+    pub fn transaction_monitoring_confirmations() -> usize {
+        2
+    }
+
+    pub fn metrics_port() -> u16 {
+        9090
     }
 }
 

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -47,7 +47,7 @@ pub struct Config {
     pub protocol_chain: ProtocolChain,
     pub retry_strategy_max_wait_time: Duration,
     pub metrics_port: u16,
-    pub transaction_confirmation_count: usize,
+    pub transaction_confirmation_timeout: Duration,
 }
 
 impl Config {
@@ -90,7 +90,9 @@ impl Config {
                 ),
             },
             metrics_port: config_file.metrics_port,
-            transaction_confirmation_count: config_file.transaction_confirmation_count,
+            transaction_confirmation_timeout: Duration::from_secs(
+                config_file.transaction_confirmation_timeout_in_seconds,
+            ),
         }
     }
 }
@@ -112,8 +114,8 @@ struct ConfigFile {
     freshness_threshold: u64,
     #[serde(default = "serde_defaults::web3_transport_retry_max_wait_time_in_seconds")]
     web3_transport_retry_max_wait_time_in_seconds: u64,
-    #[serde(default = "serde_defaults::transaction_confirmation_count")]
-    transaction_confirmation_count: usize,
+    #[serde(default = "serde_defaults::transaction_confirmation_timeout_in_seconds")]
+    transaction_confirmation_timeout_in_seconds: u64,
     #[serde(default = "serde_defaults::log_level")]
     log_level: FromStrWrapper<LevelFilter>,
     protocol_chain: SerdeProtocolChain,
@@ -206,8 +208,8 @@ mod serde_defaults {
         60
     }
 
-    pub fn transaction_confirmation_count() -> usize {
-        15
+    pub fn transaction_confirmation_timeout_in_seconds() -> u64 {
+        120
     }
 
     pub fn metrics_port() -> u16 {

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -48,6 +48,8 @@ pub struct Config {
     pub retry_strategy_max_wait_time: Duration,
     pub metrics_port: u16,
     pub transaction_confirmation_timeout: Duration,
+    pub transaction_monitoring_max_retries: u32,
+    pub transaction_monitoring_gas_increase_rate: f32,
 }
 
 impl Config {
@@ -93,6 +95,9 @@ impl Config {
             transaction_confirmation_timeout: Duration::from_secs(
                 config_file.transaction_confirmation_timeout_in_seconds,
             ),
+            transaction_monitoring_max_retries: config_file.transaction_monitoring_max_retries,
+            transaction_monitoring_gas_increase_rate: config_file
+                .transaction_monitoring_gas_increase_rate,
         }
     }
 }
@@ -116,6 +121,10 @@ struct ConfigFile {
     web3_transport_retry_max_wait_time_in_seconds: u64,
     #[serde(default = "serde_defaults::transaction_confirmation_timeout_in_seconds")]
     transaction_confirmation_timeout_in_seconds: u64,
+    #[serde(default = "serde_defaults::transaction_monitoring_max_retries")]
+    transaction_monitoring_max_retries: u32,
+    #[serde(default = "serde_defaults::transaction_monitoring_gas_increase_rate")]
+    transaction_monitoring_gas_increase_rate: f32,
     #[serde(default = "serde_defaults::log_level")]
     log_level: FromStrWrapper<LevelFilter>,
     protocol_chain: SerdeProtocolChain,
@@ -210,6 +219,13 @@ mod serde_defaults {
 
     pub fn transaction_confirmation_timeout_in_seconds() -> u64 {
         120
+    }
+    pub fn transaction_monitoring_max_retries() -> u32 {
+        10
+    }
+
+    pub fn transaction_monitoring_gas_increase_rate() -> f32 {
+        0.5 // 50%
     }
 
     pub fn metrics_port() -> u16 {

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -51,7 +51,7 @@ pub struct TransactionMonitoringOptions {
     /// How many confirmations to wait for
     #[serde(default = "serde_defaults::transaction_monitoring_confirmations")]
     pub confirmations: usize,
-    #[serde(default)]
+    #[serde(default = "serde_defaults::transaction_monitoring_gas_limit")]
     pub gas_limit: u64,
     #[serde(default)]
     pub max_fee_per_gas: Option<u64>,
@@ -69,7 +69,7 @@ impl Default for TransactionMonitoringOptions {
             gas_percentual_increase: transaction_monitoring_gas_percentual_increase(),
             poll_interval_in_seconds: transaction_monitoring_poll_interval_in_seconds(),
             confirmations: transaction_monitoring_confirmations(),
-            gas_limit: 0,
+            gas_limit: transaction_monitoring_gas_limit(),
             max_fee_per_gas: None,
             max_priority_fee_per_gas: None,
         }
@@ -267,6 +267,10 @@ mod serde_defaults {
 
     pub fn transaction_monitoring_confirmations() -> usize {
         2
+    }
+
+    pub fn transaction_monitoring_gas_limit() -> u64 {
+        100_000
     }
 
     pub fn metrics_port() -> u16 {

--- a/crates/oracle/src/config.rs
+++ b/crates/oracle/src/config.rs
@@ -42,9 +42,9 @@ pub struct TransactionMonitoringOptions {
     #[serde(default = "serde_defaults::transaction_monitoring_max_retries")]
     /// How many times it has tried to rebroadcast the original transaction.
     pub max_retries: u32,
-    /// Gas price increase factor
-    #[serde(default = "serde_defaults::transaction_monitoring_gas_increase_rate")]
-    pub gas_increase_rate: f32,
+    /// Gas price percentual increase
+    #[serde(default = "serde_defaults::transaction_monitoring_gas_percentual_increase")]
+    pub gas_percentual_increase: u32,
 }
 
 #[derive(Clone, Debug)]
@@ -227,8 +227,8 @@ mod serde_defaults {
         10
     }
 
-    pub fn transaction_monitoring_gas_increase_rate() -> f32 {
-        0.5 // 50%
+    pub fn transaction_monitoring_gas_percentual_increase() -> u32 {
+        50 // 50%
     }
 
     pub fn metrics_port() -> u16 {
@@ -240,7 +240,7 @@ mod serde_defaults {
             confirmation_timeout_in_seconds: transaction_monitoring_confirmation_timeout_in_seconds(
             ),
             max_retries: transaction_monitoring_max_retries(),
-            gas_increase_rate: transaction_monitoring_gas_increase_rate(),
+            gas_percentual_increase: transaction_monitoring_gas_percentual_increase(),
         }
     }
 }

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -95,7 +95,7 @@ where
 
             let transaction_monitor = TransactionMonitor::new(
                 self.client.clone(),
-                SecretKeyRef::new(&owner_private_key),
+                SecretKeyRef::new(owner_private_key),
                 self.data_edge.address(),
                 calldata,
                 self.transaction_monitoring_options,

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -24,6 +24,8 @@ where
     epoch_manager: Contract<T>,
     confirmation_timeout: Duration,
     client: Web3<T>,
+    transaction_monitoring_max_retries: u32,
+    transaction_monitoring_gas_increase_rate: f32,
 }
 
 impl<T> Contracts<T>
@@ -35,6 +37,8 @@ where
         data_edge_address: Address,
         epoch_manager_address: Address,
         confirmation_timeout: Duration,
+        transaction_monitoring_max_retries: u32,
+        transaction_monitoring_gas_increase_rate: f32,
     ) -> anyhow::Result<Self> {
         let data_edge = Contracts::new_contract(DATA_EDGE_ABI, &client.eth(), data_edge_address)?;
         let epoch_manager =
@@ -44,6 +48,8 @@ where
             data_edge,
             epoch_manager,
             confirmation_timeout,
+            transaction_monitoring_max_retries,
+            transaction_monitoring_gas_increase_rate,
         })
     }
 
@@ -86,8 +92,8 @@ where
                 owner_private_key,
                 self.data_edge.address(),
                 calldata,
-                todo!("max_retries"),
-                todo!("gas_increase_rate"),
+                self.transaction_monitoring_max_retries,
+                self.transaction_monitoring_gas_increase_rate,
                 self.confirmation_timeout,
             );
 

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -3,7 +3,6 @@ use crate::{
 };
 use anyhow::Context;
 use secp256k1::SecretKey;
-use std::time::Duration;
 use tracing::{debug, info, trace};
 use web3::{
     api::Eth,
@@ -83,15 +82,15 @@ where
             let calldata: web3::types::Bytes =
                 self.abi_encode_data_edge_payload((payload,))?.into();
 
-            let monitor = TransactionMonitor::new(
+            let transaction_monitor = TransactionMonitor::new(
                 self.client.clone(),
                 owner_private_key,
                 self.data_edge.address(),
                 calldata,
                 self.transaction_monitoring_options,
-            );
-
-            todo!("execute the transaction monitoring step")
+            )
+            .await?;
+            transaction_monitor.execute_transaction().await?
         };
 
         info!(?transaction_receipt.transaction_hash, "Transaction confirmed");

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -1,4 +1,6 @@
-use crate::{metrics::METRICS, transaction_monitor::TransactionMonitor};
+use crate::{
+    config::TransactionMonitoringOptions, metrics::METRICS, transaction_monitor::TransactionMonitor,
+};
 use anyhow::Context;
 use secp256k1::SecretKey;
 use std::time::Duration;
@@ -20,12 +22,10 @@ pub struct Contracts<T>
 where
     T: Clone + Transport,
 {
+    client: Web3<T>,
     data_edge: Contract<T>,
     epoch_manager: Contract<T>,
-    confirmation_timeout: Duration,
-    client: Web3<T>,
-    transaction_monitoring_max_retries: u32,
-    transaction_monitoring_gas_increase_rate: f32,
+    transaction_monitoring_options: TransactionMonitoringOptions,
 }
 
 impl<T> Contracts<T>
@@ -36,9 +36,7 @@ where
         client: Web3<T>,
         data_edge_address: Address,
         epoch_manager_address: Address,
-        confirmation_timeout: Duration,
-        transaction_monitoring_max_retries: u32,
-        transaction_monitoring_gas_increase_rate: f32,
+        transaction_monitoring_options: TransactionMonitoringOptions,
     ) -> anyhow::Result<Self> {
         let data_edge = Contracts::new_contract(DATA_EDGE_ABI, &client.eth(), data_edge_address)?;
         let epoch_manager =
@@ -47,9 +45,7 @@ where
             client,
             data_edge,
             epoch_manager,
-            confirmation_timeout,
-            transaction_monitoring_max_retries,
-            transaction_monitoring_gas_increase_rate,
+            transaction_monitoring_options,
         })
     }
 
@@ -92,9 +88,7 @@ where
                 owner_private_key,
                 self.data_edge.address(),
                 calldata,
-                self.transaction_monitoring_max_retries,
-                self.transaction_monitoring_gas_increase_rate,
-                self.confirmation_timeout,
+                self.transaction_monitoring_options,
             );
 
             todo!("execute the transaction monitoring step")

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -104,7 +104,6 @@ where
             transaction_monitor.execute_transaction().await?
         };
 
-        info!(?transaction_receipt.transaction_hash, "Transaction confirmed");
         Ok(transaction_receipt)
     }
 

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -8,6 +8,7 @@ use web3::{
     api::Eth,
     contract::{tokens::Tokenize, Contract},
     ethabi::Address,
+    signing::SecretKeyRef,
     types::{TransactionReceipt, U256},
     Transport, Web3,
 };
@@ -84,7 +85,7 @@ where
 
             let transaction_monitor = TransactionMonitor::new(
                 self.client.clone(),
-                owner_private_key,
+                SecretKeyRef::new(&owner_private_key),
                 self.data_edge.address(),
                 calldata,
                 self.transaction_monitoring_options,

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -88,4 +88,14 @@ where
         info!(?transaction_receipt.transaction_hash, "Transaction confirmed");
         Ok(transaction_receipt)
     }
+
+    pub fn abi_encode_data_edge_payload(
+        &self,
+        params: impl Tokenize,
+    ) -> Result<Vec<u8>, web3::ethabi::Error> {
+        self.data_edge
+            .abi()
+            .function(DATA_EDGE_FUNCTION_NAME)
+            .and_then(|function| function.encode_input(&params.into_tokens()))
+    }
 }

--- a/crates/oracle/src/contracts.rs
+++ b/crates/oracle/src/contracts.rs
@@ -1,10 +1,11 @@
 use crate::metrics::METRICS;
 use anyhow::Context;
 use secp256k1::SecretKey;
+use std::time::Duration;
 use tracing::{debug, info, trace};
 use web3::{
     api::Eth,
-    contract::{tokens::Tokenize, Contract, Options},
+    contract::{tokens::Tokenize, Contract},
     ethabi::Address,
     types::{TransactionReceipt, U256},
     Transport,
@@ -21,7 +22,7 @@ where
 {
     data_edge: Contract<T>,
     epoch_manager: Contract<T>,
-    confirmations: usize,
+    confirmation_timeout: Duration,
 }
 
 impl<T> Contracts<T>
@@ -32,14 +33,14 @@ where
         eth: &Eth<T>,
         data_edge_address: Address,
         epoch_manager_address: Address,
-        confirmations: usize,
+        confirmation_timeout: Duration,
     ) -> anyhow::Result<Self> {
         let data_edge = Contracts::new_contract(DATA_EDGE_ABI, eth, data_edge_address)?;
         let epoch_manager = Contracts::new_contract(EPOCH_MANAGER_ABI, eth, epoch_manager_address)?;
         Ok(Self {
             data_edge,
             epoch_manager,
-            confirmations,
+            confirmation_timeout,
         })
     }
 
@@ -71,20 +72,8 @@ where
         payload: Vec<u8>,
         owner_private_key: &SecretKey,
     ) -> Result<TransactionReceipt, web3::contract::Error> {
-        info!(
-            "Sending transaction and waiting for {} confirmations",
-            self.confirmations
-        );
-        let transaction_receipt = self
-            .data_edge
-            .signed_call_with_confirmations(
-                DATA_EDGE_FUNCTION_NAME,
-                (payload,),
-                Options::default(),
-                self.confirmations,
-                owner_private_key,
-            )
-            .await?;
+        info!("Sending transaction and waiting for confirmations",);
+        let transaction_receipt: TransactionReceipt = todo!("transaction monitor here");
         info!(?transaction_receipt.transaction_hash, "Transaction confirmed");
         Ok(transaction_receipt)
     }

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -106,8 +106,6 @@ fn init_contracts(config: Config) -> anyhow::Result<Contracts<Http>> {
         protocol_chain.web3.clone(),
         config.data_edge_address,
         config.epoch_manager_address,
-        config.transaction_confirmation_timeout,
-        config.transaction_monitoring_max_retries,
-        config.transaction_monitoring_gas_increase_rate,
+        config.transaction_monitoring_options,
     )
 }

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -103,7 +103,7 @@ fn init_contracts(config: Config) -> anyhow::Result<Contracts<Http>> {
     let transport = Http::new(config.protocol_chain.jrpc_url.as_str())?;
     let protocol_chain = JrpcProviderForChain::new(config.protocol_chain.id, transport);
     Contracts::new(
-        protocol_chain.web3.clone(),
+        protocol_chain.web3,
         config.data_edge_address,
         config.epoch_manager_address,
         config.transaction_monitoring_options,

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -103,7 +103,7 @@ fn init_contracts(config: Config) -> anyhow::Result<Contracts<Http>> {
     let transport = Http::new(config.protocol_chain.jrpc_url.as_str())?;
     let protocol_chain = JrpcProviderForChain::new(config.protocol_chain.id, transport);
     Contracts::new(
-        &protocol_chain.web3.eth(),
+        protocol_chain.web3.clone(),
         config.data_edge_address,
         config.epoch_manager_address,
         config.transaction_confirmation_timeout,

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -106,6 +106,6 @@ fn init_contracts(config: Config) -> anyhow::Result<Contracts<Http>> {
         &protocol_chain.web3.eth(),
         config.data_edge_address,
         config.epoch_manager_address,
-        config.transaction_confirmation_count,
+        config.transaction_confirmation_timeout,
     )
 }

--- a/crates/oracle/src/main.rs
+++ b/crates/oracle/src/main.rs
@@ -107,5 +107,7 @@ fn init_contracts(config: Config) -> anyhow::Result<Contracts<Http>> {
         config.data_edge_address,
         config.epoch_manager_address,
         config.transaction_confirmation_timeout,
+        config.transaction_monitoring_max_retries,
+        config.transaction_monitoring_gas_increase_rate,
     )
 }

--- a/crates/oracle/src/runner/mod.rs
+++ b/crates/oracle/src/runner/mod.rs
@@ -40,8 +40,6 @@ pub enum Error {
     SubgraphNotFresh,
     #[error("The subgraph has not been initialized yet")]
     SubgraphNotInitialized,
-    #[error("The subgraph's global state has no registered networks")]
-    SubgraphWithoutRegisteredNetworks,
 }
 
 impl MainLoopFlow for Error {
@@ -60,7 +58,6 @@ impl MainLoopFlow for Error {
             // TODO: Put those variants under the `SubgraphQueryError` enum
             SubgraphNotFresh => OracleControlFlow::Continue(2),
             SubgraphNotInitialized => OracleControlFlow::Continue(2),
-            SubgraphWithoutRegisteredNetworks => OracleControlFlow::Continue(2),
         }
     }
 }

--- a/crates/oracle/src/runner/mod.rs
+++ b/crates/oracle/src/runner/mod.rs
@@ -2,6 +2,7 @@ pub mod ctrlc;
 pub mod error_handling;
 pub mod jrpc_utils;
 pub mod oracle;
+pub mod transaction_monitor;
 
 use self::ctrlc::CtrlcHandler;
 use crate::metrics::{metrics_server, METRICS};

--- a/crates/oracle/src/runner/mod.rs
+++ b/crates/oracle/src/runner/mod.rs
@@ -5,6 +5,7 @@ pub mod oracle;
 pub mod transaction_monitor;
 
 use self::ctrlc::CtrlcHandler;
+use crate::contracts::ContractError;
 use crate::metrics::{metrics_server, METRICS};
 use crate::{Caip2ChainId, Config, SubgraphQueryError};
 use error_handling::{MainLoopFlow, OracleControlFlow};
@@ -29,8 +30,8 @@ pub enum Error {
     },
     #[error(transparent)]
     Subgraph(#[from] SubgraphQueryError),
-    #[error("Couldn't submit a transaction to the mempool of the JRPC provider: {0}")]
-    CantSubmitTx(web3::contract::Error),
+    #[error(transparent)]
+    ContractError(#[from] ContractError),
     #[error("Failed to call Epoch Manager")]
     EpochManagerCallFailed(#[from] web3::contract::Error),
     #[error("Epoch Manager latest epoch ({manager}) is behind Epoch Subgraph's ({subgraph})")]
@@ -50,7 +51,7 @@ impl MainLoopFlow for Error {
             BadJrpcIndexedChain { .. } => OracleControlFlow::Continue(0),
 
             // TODO: Put those variants under a new `contracts::Error` enum
-            CantSubmitTx(_) => OracleControlFlow::Continue(0),
+            ContractError(_) => OracleControlFlow::Continue(0),
             EpochManagerCallFailed(_) => OracleControlFlow::Continue(0),
             EpochManagerBehindSubgraph { .. } => OracleControlFlow::Continue(0),
 

--- a/crates/oracle/src/runner/mod.rs
+++ b/crates/oracle/src/runner/mod.rs
@@ -40,6 +40,8 @@ pub enum Error {
     SubgraphNotFresh,
     #[error("The subgraph has not been initialized yet")]
     SubgraphNotInitialized,
+    #[error("The subgraph's global state has no registered networks")]
+    SubgraphWithoutRegisteredNetworks,
 }
 
 impl MainLoopFlow for Error {
@@ -58,6 +60,7 @@ impl MainLoopFlow for Error {
             // TODO: Put those variants under the `SubgraphQueryError` enum
             SubgraphNotFresh => OracleControlFlow::Continue(2),
             SubgraphNotInitialized => OracleControlFlow::Continue(2),
+            SubgraphWithoutRegisteredNetworks => OracleControlFlow::Continue(2),
         }
     }
 }

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -120,11 +120,6 @@ impl Oracle {
             }
         };
 
-        // Go back to sleep if the Epoch Subgraph has no registered networks
-        if matches!(subgraph_state.network_count(), None | Some(0)) {
-            return Err(Error::SubgraphWithoutRegisteredNetworks);
-        }
-
         debug!("Subgraph is at epoch {subgraph_latest_epoch}");
         METRICS.set_current_epoch("subgraph", subgraph_latest_epoch as i64);
         let manager_current_epoch = self.contracts.query_current_epoch().await?;

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -120,6 +120,11 @@ impl Oracle {
             }
         };
 
+        // Go back to sleep if the Epoch Subgraph has no registered networks
+        if matches!(subgraph_state.network_count(), None | Some(0)) {
+            return Err(Error::SubgraphWithoutRegisteredNetworks);
+        }
+
         debug!("Subgraph is at epoch {subgraph_latest_epoch}");
         METRICS.set_current_epoch("subgraph", subgraph_latest_epoch as i64);
         let manager_current_epoch = self.contracts.query_current_epoch().await?;

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -179,7 +179,7 @@ impl Oracle {
             .map_err(Error::ContractError)?;
         METRICS.set_last_sent_message();
         info!(
-            tx_hash = transaction_receipt.transaction_hash.to_string().as_str(),
+            tx_hash = %transaction_receipt.transaction_hash,
             "Contract call submitted successfully."
         );
 

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -171,7 +171,7 @@ impl Oracle {
             .contracts
             .submit_call(payload, &self.config.owner_private_key)
             .await
-            .map_err(Error::CantSubmitTx)?;
+            .map_err(Error::ContractError)?;
         METRICS.set_last_sent_message();
         info!(
             tx_hash = transaction_receipt.transaction_hash.to_string().as_str(),

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -27,6 +27,8 @@ impl Oracle {
             config.data_edge_address,
             config.epoch_manager_address,
             config.transaction_confirmation_timeout,
+            config.transaction_monitoring_max_retries,
+            config.transaction_monitoring_gas_increase_rate,
         )
         .expect("Failed to initialize Block Oracle's required contracts");
 

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -179,7 +179,7 @@ impl Oracle {
             .map_err(Error::ContractError)?;
         METRICS.set_last_sent_message();
         info!(
-            tx_hash = %transaction_receipt.transaction_hash,
+            tx_hash = ?transaction_receipt.transaction_hash,
             "Contract call submitted successfully."
         );
 

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -26,9 +26,7 @@ impl Oracle {
             protocol_chain.web3.clone(),
             config.data_edge_address,
             config.epoch_manager_address,
-            config.transaction_confirmation_timeout,
-            config.transaction_monitoring_max_retries,
-            config.transaction_monitoring_gas_increase_rate,
+            config.transaction_monitoring_options,
         )
         .expect("Failed to initialize Block Oracle's required contracts");
 

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -70,9 +70,6 @@ impl Oracle {
                 subgraph_latest_indexed_block,
             }) => subgraph_latest_indexed_block,
 
-            // It is always a new epoch for an uninitialized Epoch Subgraph.
-            Err(Error::SubgraphNotInitialized) => return Ok(true),
-
             Err(other) => return Err(other),
         };
 

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -28,7 +28,7 @@ impl Oracle {
             &protocol_chain.web3.eth(),
             config.data_edge_address,
             config.epoch_manager_address,
-            config.transaction_confirmation_count,
+            config.transaction_confirmation_timeout,
         )
         .expect("Failed to initialize Block Oracle's required contracts");
 

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -140,10 +140,10 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
                 Err(Either::Right(transaction_hash)) => {
                     // This means that we timed out waiting for the transaction to be confirmed.
                     sent_transactions.insert(transaction_hash);
-                    transaction_parameters.gas_price.as_mut().map(|gas| {
+                    if let Some(gas) = transaction_parameters.gas_price.as_mut() {
                         *gas = bump_gas(*gas, self.options.gas_percentual_increase)
                             .expect("gas_price calculation won't overflow a 256-bit number")
-                    });
+                    }
                     retries -= 1;
                 }
             };

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -91,7 +91,10 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
         for hash in &sent_transaction_hashes {
             let eth = self.client.eth();
             let future = async move {
-                trace!( %hash, "Checking for previously sent transaction confirmations");
+                trace!(
+                    ?hash,
+                    "Checking for previously sent transaction confirmations"
+                );
                 eth.transaction_receipt(*hash).await
             };
             futures.push(future)
@@ -194,7 +197,7 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
                             .expect("gas_price calculation won't overflow a 256-bit number")
                     }
                     retries -= 1;
-                    debug!(%transaction_hash, retries_left = %retries, "Timed out waiting for the transaction confirmation");
+                    debug!(?transaction_hash, retries_left = %retries, "Timed out waiting for the transaction confirmation");
                 }
             };
         }

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -30,10 +30,6 @@ pub struct TransactionMonitor<'a, T: Transport> {
     /// We keep it around so we can control its `nonce` and `gas_price` values.
     transaction_parameters: TransactionParameters,
 
-    /// Holds the hashes of previously sent transactions, so it can check if any of them got anyt
-    /// confirmations.
-    sent_transaction_hashes: HashSet<H256>,
-
     options: TransactionMonitoringOptions,
 }
 
@@ -71,7 +67,6 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
             transaction_parameters,
             signing_key,
             options,
-            sent_transaction_hashes: Default::default(),
         })
     }
 

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -3,7 +3,7 @@ use std::collections::HashSet;
 use web3::{
     error::Error as Web3Error,
     signing::Key,
-    types::{Address, Bytes, TransactionRequest, H256},
+    types::{Address, Bytes, TransactionReceipt, TransactionRequest, H256},
     Transport, Web3,
 };
 
@@ -64,5 +64,26 @@ impl<T: Transport, K: Key> TransactionMonitor<T, K> {
             options,
             sent_transaction_hashes: Default::default(),
         })
+    }
+
+    /// It is possible that previously sent transactions are included in a block while we are trying
+    /// to rebroadcast the original transaction.
+    ///
+    /// If this function detects any confirmation the TransactionManager should abort its ongoing
+    /// operations and return the transaction hash of the confirmed transaction to the Oracle.
+    async fn check_previously_sent_transactions(
+        &self,
+    ) -> Result<TransactionReceipt, TransactionMonitorError> {
+        todo!()
+    }
+
+    /// Broadcasts the transaction and waits for its confirmation.
+    ///
+    /// It will bump the gas price and retry if the transaction takes too long to confirm.
+    /// While doing so, it will also check if previously sent transactions were confirmed.
+    ///
+    /// This function will return an error if we exhaust its maximum retries attempts.
+    pub async fn execute_transaction(&self) -> Result<TransactionReceipt, TransactionMonitorError> {
+        todo!()
     }
 }

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -1,3 +1,4 @@
+use crate::config::TransactionMonitoringOptions;
 use std::collections::HashSet;
 use web3::{
     error::Error as Web3Error,
@@ -24,14 +25,7 @@ pub struct TransactionMonitor<T: Transport, K: Key> {
     /// confirmations.
     sent_transaction_hashes: HashSet<H256>,
 
-    /// How many times it has tried to rebroadcast the original transaction.
-    max_retries: u32,
-
-    /// Gas price increase factor
-    gas_increase_rate: f32,
-
-    /// How long to wait for a transaction to be confirmed
-    transaction_confirmation_timeout: tokio::time::Duration,
+    options: TransactionMonitoringOptions,
 }
 
 impl<T: Transport, K: Key> TransactionMonitor<T, K> {
@@ -40,9 +34,7 @@ impl<T: Transport, K: Key> TransactionMonitor<T, K> {
         signing_key: K,
         contract_address: Address,
         calldata: Bytes,
-        max_retries: u32,
-        gas_increase_rate: f32,
-        transaction_confirmation_timeout: tokio::time::Duration,
+        options: TransactionMonitoringOptions,
     ) -> Result<Self, TransactionMonitorError> {
         let from = signing_key.address();
 
@@ -69,9 +61,7 @@ impl<T: Transport, K: Key> TransactionMonitor<T, K> {
             client,
             transaction_request,
             signing_key,
-            max_retries,
-            gas_increase_rate,
-            transaction_confirmation_timeout,
+            options,
             sent_transaction_hashes: Default::default(),
         })
     }

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -1,0 +1,78 @@
+use std::collections::HashSet;
+use web3::{
+    error::Error as Web3Error,
+    signing::Key,
+    types::{Address, Bytes, TransactionRequest, H256},
+    Transport, Web3,
+};
+
+#[derive(thiserror::Error, Debug)]
+pub enum TransactionMonitorError {
+    #[error("failed to determine default values for crafting the transaction")]
+    Startup(#[source] Web3Error),
+}
+
+pub struct TransactionMonitor<T: Transport, K: Key> {
+    client: Web3<T>,
+    signing_key: K,
+
+    /// The unsingned transaction that we want to broadcast.
+    /// We keep it around so we can control its `nonce` and `gas_price` values.
+    transaction_request: TransactionRequest,
+
+    /// Holds the hashes of previously sent transactions, so it can check if any of them got anyt
+    /// confirmations.
+    sent_transaction_hashes: HashSet<H256>,
+
+    /// How many times it has tried to rebroadcast the original transaction.
+    max_retries: u32,
+
+    /// Gas price increase factor
+    gas_increase_rate: f32,
+
+    /// How long to wait for a transaction to be confirmed
+    transaction_confirmation_timeout: tokio::time::Duration,
+}
+
+impl<T: Transport, K: Key> TransactionMonitor<T, K> {
+    pub async fn new(
+        client: Web3<T>,
+        signing_key: K,
+        contract_address: Address,
+        calldata: Bytes,
+        max_retries: u32,
+        gas_increase_rate: f32,
+        transaction_confirmation_timeout: tokio::time::Duration,
+    ) -> Result<Self, TransactionMonitorError> {
+        let from = signing_key.address();
+
+        let (nonce, gas_price) = futures::future::try_join(
+            client.eth().transaction_count(from, None),
+            client.eth().gas_price(),
+        )
+        .await
+        .map_err(TransactionMonitorError::Startup)?;
+
+        let transaction_request = TransactionRequest {
+            from,
+            to: Some(contract_address),
+            gas: todo!("should we set a fixed gas limit?"),
+            gas_price: Some(gas_price),
+            data: Some(calldata),
+            nonce: Some(nonce),
+            max_fee_per_gas: todo!("how should we set this?"),
+            max_priority_fee_per_gas: todo!("how should we set this?"),
+            ..Default::default()
+        };
+
+        Ok(Self {
+            client,
+            transaction_request,
+            signing_key,
+            max_retries,
+            gas_increase_rate,
+            transaction_confirmation_timeout,
+            sent_transaction_hashes: Default::default(),
+        })
+    }
+}

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -121,7 +121,9 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
         &self,
         transaction_parameters: TransactionParameters,
     ) -> Result<TransactionReceipt, Either<Web3Error, H256>> {
-        trace!(?transaction_parameters, "Broadcasting transaction");
+        // we will log this later
+        let gas = transaction_parameters.gas;
+
         // Sign the transaction
         let signed_transaction = Accounts::new(self.client.transport().clone())
             .sign_transaction(transaction_parameters, &*self.signing_key)
@@ -129,6 +131,8 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
             .map_err(Either::Left)?;
 
         let transaction_hash = signed_transaction.transaction_hash;
+
+        trace!(hash = ?transaction_hash, %gas, "Broadcasting transaction");
 
         // Wrap the transaction broadcast in a tokio::timeout future
         let send_transaction_future = web3::confirm::send_raw_transaction_with_confirmation(

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -128,7 +128,7 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
         let mut sent_transactions = HashSet::new();
         let mut transaction_parameters = self.transaction_parameters.clone();
 
-        while retries >= 0 {
+        while retries > 0 {
             match self
                 .send_transaction_and_wait_for_confirmation(transaction_parameters.clone())
                 .await

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -110,12 +110,6 @@ pub struct SubgraphState {
     pub last_payload: Option<Payload>,
 }
 
-impl SubgraphState {
-    pub fn network_count(&self) -> Option<usize> {
-        self.global_state.as_ref().map(|gs| gs.networks.len())
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalState {
     pub networks: Vec<Network>,

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -110,6 +110,12 @@ pub struct SubgraphState {
     pub last_payload: Option<Payload>,
 }
 
+impl SubgraphState {
+    pub fn network_count(&self) -> Option<usize> {
+        self.global_state.as_ref().map(|gs| gs.networks.len())
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalState {
     pub networks: Vec<Network>,

--- a/crates/oracle/src/subgraph.rs
+++ b/crates/oracle/src/subgraph.rs
@@ -110,6 +110,22 @@ pub struct SubgraphState {
     pub last_payload: Option<Payload>,
 }
 
+impl SubgraphState {
+    pub fn latest_epoch_number(&self) -> Option<u64> {
+        self.global_state
+            .as_ref()
+            .and_then(|gs| gs.latest_epoch_number)
+    }
+
+    pub fn has_registered_networks(&self) -> bool {
+        self.global_state
+            .as_ref()
+            .map(|gs| gs.networks.len())
+            .unwrap_or(0)
+            > 0
+    }
+}
+
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct GlobalState {
     pub networks: Vec<Network>,

--- a/crates/xtask/src/message_samples.rs
+++ b/crates/xtask/src/message_samples.rs
@@ -26,7 +26,7 @@ fn compile() -> anyhow::Result<()> {
 }
 
 pub fn encode(calldata: bool) -> anyhow::Result<()> {
-    let calldata = calldata.then(|| "--calldata");
+    let calldata = calldata.then_some("--calldata");
     compile()?;
     let sh = Shell::new()?;
     cmd!(sh, "cargo build --package block-oracle")

--- a/k8s/compose/config.toml
+++ b/k8s/compose/config.toml
@@ -6,6 +6,15 @@ epoch_manager_address = "$EPOCH_MANAGER_CONTRACT_ADDRESS"
 subgraph_url = "$SUBGRAPH_URL"
 bearer_token = "TODO"
 
+[transaction_monitoring]
+confirmation_timeout_in_seconds = 1
+max_retries = 3
+gas_percentual_increase = 10
+pol_interval_in_seconds = 1
+confirmations = 2
+
+
+
 [protocol_chain]
 name = "eip155:1337"
 jrpc = "$PROTOCOL_CHAIN_JRPC_URL"

--- a/k8s/compose/config.toml
+++ b/k8s/compose/config.toml
@@ -12,5 +12,4 @@ jrpc = "$PROTOCOL_CHAIN_JRPC_URL"
 polling_interval_in_seconds = 5
 
 [indexed_chains]
-"eip155:77" = "https://sokol-archive.blockscout.com/" # POA Network Sokol
-"eip155:99" = "https://core-archive.blockscout.com/"  # POA Network Core
+"eip155:1337" = "$PROTOCOL_CHAIN_JRPC_URL" # index the protocol chain itself

--- a/k8s/compose/contracts/seed-then-set-automining-interval.js
+++ b/k8s/compose/contracts/seed-then-set-automining-interval.js
@@ -1,7 +1,6 @@
 async function main() {
   const epochManagerAddress = process.env.EPOCH_MANAGER_CONTRACT_ADDRESS;
   const dataEdgeAddress = process.env.DATA_EDGE_CONTRACT_ADDRESS;
-  console.table({ epochManagerAddress, dataEdgeAddress });
   const [signer] = await ethers.getSigners();
   const epochManager = await ethers.getContractAt(
     "EpochManager",

--- a/k8s/compose/contracts/seed-then-set-automining-interval.js
+++ b/k8s/compose/contracts/seed-then-set-automining-interval.js
@@ -1,15 +1,29 @@
 async function main() {
+  const epochManagerAddress = process.env.EPOCH_MANAGER_CONTRACT_ADDRESS;
+  const dataEdgeAddress = process.env.DATA_EDGE_CONTRACT_ADDRESS;
+  console.table({ epochManagerAddress, dataEdgeAddress });
+  const [signer] = await ethers.getSigners();
+  const epochManager = await ethers.getContractAt(
+    "EpochManager",
+    epochManagerAddress,
+    signer
+  );
+
   // RegisterNetworks message: add network eip155:1337 (same as protocol chain)
   // This is necessary because since commit #cc729541e5d3fe0a11ef7f9a4382dd693525eb9e the Epoch Block Oracle won't send the RegisterNetworks message.
   await network.provider.send("eth_sendTransaction", [
     {
-      from: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
-      to: "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab",
+      from: signer.address,
+      to: dataEdgeAddress,
       data: "0xa1dce3320000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f030103176569703135353a313333370000000000000000000000000000000000",
     },
   ]);
-  //
+
+  // set hardhat to produce blocks every 2 seconds
   await network.provider.send("evm_setIntervalMining", [2000]);
+
+  // set epoch length
+  await epochManager.setEpochLength(2);
 }
 
 main()

--- a/k8s/compose/contracts/seed-then-set-automining-interval.js
+++ b/k8s/compose/contracts/seed-then-set-automining-interval.js
@@ -1,15 +1,20 @@
 async function main() {
-	await network.provider.send('eth_sendTransaction', [{
-		from: '0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1',
-		to: '0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab',
-		data: '0xa1dce33200000000000000000000000000000000000000000000000000000000000000200000000000000000000000000000000000000000000000000000000000000017030105136569703135353a3737136569703135353a3939000000000000000000'
-	}]);
-	await network.provider.send('evm_setIntervalMining', [2000]);
+  // RegisterNetworks message: add network eip155:1337 (same as protocol chain)
+  // This is necessary because since commit #cc729541e5d3fe0a11ef7f9a4382dd693525eb9e the Epoch Block Oracle won't send the RegisterNetworks message.
+  await network.provider.send("eth_sendTransaction", [
+    {
+      from: "0x90F8bf6A479f320ead074411a4B0e7944Ea8c9C1",
+      to: "0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab",
+      data: "0xa1dce3320000000000000000000000000000000000000000000000000000000000000020000000000000000000000000000000000000000000000000000000000000000f030103176569703135353a313333370000000000000000000000000000000000",
+    },
+  ]);
+  //
+  await network.provider.send("evm_setIntervalMining", [2000]);
 }
 
 main()
-	.then(() => process.exit(0))
-	.catch((error) => {
-		console.error(error)
-		process.exit(1)
-	})
+  .then(() => process.exit(0))
+  .catch((error) => {
+    console.error(error);
+    process.exit(1);
+  });

--- a/k8s/compose/docker-compose.yml
+++ b/k8s/compose/docker-compose.yml
@@ -86,6 +86,9 @@ services:
       context: ../../packages/contracts
       dockerfile: ../../k8s/compose/contracts/Dockerfile
     command: sh /app/run.sh
+    environment:
+      EPOCH_MANAGER_CONTRACT_ADDRESS: '0xd833215cbcc3f914bd1c9ece3ee7bf8b14f841bb'
+      DATA_EDGE_CONTRACT_ADDRESS: '0xe78a0f7e598cc8b0bb87894b0f60dd2a88d6a8ab'
     volumes:
       - ./contracts/seed-then-set-automining-interval.js:/seed-then-set-automining-interval.js
       - ./contracts/extended.config.ts:/app/extended.config.ts


### PR DESCRIPTION
This PR introduces:
- The `TransactionMonitor` component, which is used by the `Contracts` module.
- A new configuration table labeled `transaction_monitoring`, where we can set all parameters that govern it.

---

**Todo:**
- [ ] update our [docs](https://github.com/graphprotocol/block-oracle/blob/main/crates/oracle/docs/transaction-monitoring.org) about transaction monitoring
- [ ] test it, somehow
- [ ] new metrics?
- [ ] wait for the `base_fee_per_gas` to be under a threshold (not sure we want this).