### PR TITLE
fix: bad math to check if a i64 can hold a wallet balance

### DIFF
--- a/crates/encoding/src/serialize.rs
+++ b/crates/encoding/src/serialize.rs
@@ -97,7 +97,7 @@ fn serialize_u64(mut value: u64, bytes: &mut Vec<u8>) {
     // The number of bytes that are needed to encode `value`. It is
     // calculated by finding the next multiple of 7 after `num_bits_to_encode`.
     // Range bounds are tricky and must be handled separately.
-    let num_bytes = (num_bits_to_encode.max(1).min(63) - 1) / 7 + 1;
+    let num_bytes = (num_bits_to_encode.clamp(1, 63) - 1) / 7 + 1;
 
     debug_assert!(num_bytes >= 1);
     debug_assert!(num_bytes <= 9);

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -115,7 +115,7 @@ impl Metrics {
         self.current_epoch
             .get_metric_with_label_values(&[label])
             .unwrap()
-            .set(current_epoch as i64);
+            .set(current_epoch);
     }
 
     pub fn set_last_sent_message(&self) {

--- a/crates/oracle/src/metrics.rs
+++ b/crates/oracle/src/metrics.rs
@@ -66,7 +66,7 @@ impl Metrics {
         )?;
 
         let wallet_balance = register_int_gauge_with_registry!(
-            "epoch_block_oracle_eth_balance",
+            "epoch_block_oracle_eth_balance_gwei",
             "Owner's ETH Balance",
             registry
         )?;

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -205,12 +205,7 @@ impl Oracle {
         info!("Owner ETH Balance is {} gwei", balance);
 
         // overflow check
-        if balance.bits() as u32 > i64::BITS - 1 {
-            // number can't be represented as positive i64
-            METRICS.set_wallet_balance(i64::MAX);
-        } else {
-            METRICS.set_wallet_balance(balance.as_u64() as i64);
-        };
+        METRICS.set_wallet_balance(i64::try_from(balance).unwrap_or(i64::MAX));
 
         Ok(())
     }

--- a/crates/oracle/src/runner/oracle.rs
+++ b/crates/oracle/src/runner/oracle.rs
@@ -205,8 +205,8 @@ impl Oracle {
         info!("Owner ETH Balance is {} gwei", balance);
 
         // overflow check
-        if balance.bits() as u32 > i64::BITS / 2 {
-            // number can't be represented as i64
+        if balance.bits() as u32 > i64::BITS - 1 {
+            // number can't be represented as positive i64
             METRICS.set_wallet_balance(i64::MAX);
         } else {
             METRICS.set_wallet_balance(balance.as_u64() as i64);


### PR DESCRIPTION
I have been seeing `9223372036854776000` in Grafana panels across all oracles, most likely caused by this bug.

I also added the unit name to the metric for explicitness.