### PR TITLE
Don't use exponential backoff for signed transactions

### DIFF
--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -102,10 +102,10 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
             futures.push(future)
         }
 
-        // Await and check if any of those transactions has a receipt
+        // Await and check if any of those transactions have a receipt
         while let Some(result) = futures.next().await {
             match result {
-                Ok(None) => {}
+                Ok(None) => { /* no confirmations */}
                 Ok(Some(receipt)) => {
                     return Ok(Some(receipt));
                 }

--- a/crates/oracle/src/runner/transaction_monitor.rs
+++ b/crates/oracle/src/runner/transaction_monitor.rs
@@ -105,7 +105,7 @@ impl<'a, T: Transport> TransactionMonitor<'a, T> {
         // Await and check if any of those transactions have a receipt
         while let Some(result) = futures.next().await {
             match result {
-                Ok(None) => { /* no confirmations */}
+                Ok(None) => { /* no confirmations */ }
                 Ok(Some(receipt)) => {
                     return Ok(Some(receipt));
                 }


### PR DESCRIPTION
Our JSON RPC connections have an unconditional retry strategy.

While this is useful for requests that only read from the chain, it also obfuscates the new transaction monitoring system.

It's crucial for such a system that transaction failures are detected immediately so it can act on them appropriately.

For this reason, this PR removes the exponential backoff mechanism for JSON RPC clients that emit signed transactions. 