### PR TITLE
Allow for hex prefix in comparison in json-encoder-web

### DIFF
--- a/packages/json-encoder-web/index.ts
+++ b/packages/json-encoder-web/index.ts
@@ -64,7 +64,7 @@ document.getElementById('verify-compiled').oninput = function () {
 	let expected = (<HTMLInputElement>document.getElementById('verify-compiled')).value;
 
 	let text;
-	if (compiled === expected) {
+	if (compiled === expected || `0x${compiled}` === expected) {
 		text = '✓ matches'
 	} else {
 		text = '✗ does not match'


### PR DESCRIPTION
Expected bytecode copied from some UIs (like Defender) has a 0x prefix. This changeset makes the comparison omit the 0x check, so we don't need to manually do it.