### PR TITLE
feat: migrate json-encoder-web from wasm-pack to direct wasm-bindgen

### DIFF
--- a/.github/workflows/web-encoder.yml
+++ b/.github/workflows/web-encoder.yml
@@ -27,7 +27,7 @@ jobs:
           target: wasm32-unknown-unknown
           override: true
       - name: Install wasm-bindgen-cli
-        run: cargo install wasm-bindgen-cli --version "0.2.88"
+        run: cargo install wasm-bindgen-cli --version "0.2.100"
       - run: npm install
         working-directory: packages/json-encoder-web
       - run: npm run build

--- a/.github/workflows/web-encoder.yml
+++ b/.github/workflows/web-encoder.yml
@@ -20,6 +20,14 @@ jobs:
           node-version: latest
           cache: "npm"
           cache-dependency-path: packages/json-encoder-web/package-lock.json
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: wasm32-unknown-unknown
+          override: true
+      - name: Install wasm-bindgen-cli
+        run: cargo install wasm-bindgen-cli --version "0.2.88"
       - run: npm install
         working-directory: packages/json-encoder-web
       - run: npm run build

--- a/packages/json-encoder-web/.gitignore
+++ b/packages/json-encoder-web/.gitignore
@@ -1,0 +1,23 @@
+# Dependencies
+node_modules/
+
+# Build outputs
+dist/
+pkg/
+target/
+
+# Logs
+npm-debug.log*
+yarn-debug.log*
+yarn-error.log*
+
+# Editor directories and files
+.idea
+.vscode
+*.swp
+*.swo
+*~
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/packages/json-encoder-web/build-wasm.js
+++ b/packages/json-encoder-web/build-wasm.js
@@ -1,0 +1,44 @@
+#!/usr/bin/env node
+const { execSync } = require('child_process');
+const fs = require('fs');
+const path = require('path');
+
+function buildWasm() {
+  console.log('🔨 Building WASM module...');
+  
+  // Clean previous build
+  if (fs.existsSync('pkg')) {
+    fs.rmSync('pkg', { recursive: true, force: true });
+  }
+  fs.mkdirSync('pkg');
+  
+  try {
+    // Compile Rust to WASM
+    console.log('📦 Compiling Rust to WASM...');
+    execSync('cargo build --target wasm32-unknown-unknown --release', {
+      stdio: 'inherit'
+    });
+    
+    // Generate bindings
+    console.log('🔗 Generating bindings...');
+    execSync(`wasm-bindgen \
+      target/wasm32-unknown-unknown/release/json_encoder_web.wasm \
+      --out-dir pkg \
+      --target bundler \
+      --no-typescript`, {
+      stdio: 'inherit'
+    });
+    
+    console.log('✅ WASM build complete!');
+  } catch (error) {
+    console.error('❌ Build failed:', error.message);
+    process.exit(1);
+  }
+}
+
+// Run if called directly
+if (require.main === module) {
+  buildWasm();
+}
+
+module.exports = { buildWasm };

--- a/packages/json-encoder-web/index.ts
+++ b/packages/json-encoder-web/index.ts
@@ -1,4 +1,4 @@
-import * as wasm from './pkg';
+import * as wasm from './pkg/json_encoder_web';
 import * as copy from 'copy-to-clipboard';
 import notie from 'notie';
 import { editor as monacoEditor } from 'monaco-editor/esm/vs/editor/editor.api'

--- a/packages/json-encoder-web/package-lock.json
+++ b/packages/json-encoder-web/package-lock.json
@@ -10,7 +10,6 @@
 			},
 			"devDependencies": {
 				"@types/notie": "^4.3.0",
-				"@wasm-tool/wasm-pack-plugin": "1.5.0",
 				"css-loader": "^6.7.1",
 				"file-loader": "^6.2.0",
 				"html-webpack-plugin": "^5.3.2",
@@ -19,342 +18,9 @@
 				"text-encoding": "^0.7.0",
 				"ts-loader": "^9.3.1",
 				"typescript": "^4.8.2",
-				"wasm-loader": "^1.3.0",
 				"webpack": "^5.49.0",
 				"webpack-cli": "^4.7.2",
 				"webpack-dev-server": "^4.10.1"
-			}
-		},
-		"node_modules/@ampproject/remapping": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/gen-mapping": "^0.1.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@ampproject/remapping/node_modules/@jridgewell/gen-mapping": {
-			"version": "0.1.1",
-			"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-			"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-			"dev": true,
-			"dependencies": {
-				"@jridgewell/set-array": "^1.0.0",
-				"@jridgewell/sourcemap-codec": "^1.4.10"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/highlight": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/compat-data": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
-			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/core": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
-			"integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
-			"dev": true,
-			"dependencies": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.13",
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helpers": "^7.18.9",
-				"@babel/parser": "^7.18.13",
-				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.13",
-				"@babel/types": "^7.18.13",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.1",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"funding": {
-				"type": "opencollective",
-				"url": "https://opencollective.com/babel"
-			}
-		},
-		"node_modules/@babel/core/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@babel/generator": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
-			"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.13",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"jsesc": "^2.5.1"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-compilation-targets": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/compat-data": "^7.18.8",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.20.2",
-				"semver": "^6.3.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			},
-			"peerDependencies": {
-				"@babel/core": "^7.0.0"
-			}
-		},
-		"node_modules/@babel/helper-compilation-targets/node_modules/semver": {
-			"version": "6.3.0",
-			"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-			"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-			"dev": true,
-			"bin": {
-				"semver": "bin/semver.js"
-			}
-		},
-		"node_modules/@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
-			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.18.6",
-				"@babel/types": "^7.18.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-module-transforms": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-simple-access": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-			"integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/types": "^7.18.6"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-string-parser": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-			"integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/helpers": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-			"integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/parser": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
-			"dev": true,
-			"bin": {
-				"parser": "bin/babel-parser.js"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
-		},
-		"node_modules/@babel/template": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-			"integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.18.10",
-				"@babel/types": "^7.18.10"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/traverse": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
-			"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.13",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.13",
-				"@babel/types": "^7.18.13",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
-		"node_modules/@babel/types": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
-			"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/helper-string-parser": "^7.18.10",
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"to-fast-properties": "^2.0.0"
-			},
-			"engines": {
-				"node": ">=6.9.0"
 			}
 		},
 		"node_modules/@discoveryjs/json-ext": {
@@ -609,18 +275,6 @@
 			"dev": true,
 			"dependencies": {
 				"@types/node": "*"
-			}
-		},
-		"node_modules/@wasm-tool/wasm-pack-plugin": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@wasm-tool/wasm-pack-plugin/-/wasm-pack-plugin-1.5.0.tgz",
-			"integrity": "sha512-qsGJ953zrXZdXW58cfYOh2nBXp0SYBsFhkxqh9p4JK8cXllEzHeRXoVO+qtgEB31+s1tsL8eda3Uy97W/7yOAg==",
-			"dev": true,
-			"dependencies": {
-				"chalk": "^2.4.1",
-				"command-exists": "^1.2.7",
-				"watchpack": "^2.1.1",
-				"which": "^2.0.2"
 			}
 		},
 		"node_modules/@webassemblyjs/ast": {
@@ -936,18 +590,6 @@
 				"node": ">=8"
 			}
 		},
-		"node_modules/ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"dependencies": {
-				"color-convert": "^1.9.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/anymatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -966,18 +608,6 @@
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
 			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
 			"dev": true
-		},
-		"node_modules/babylon": {
-			"version": "7.0.0-beta.47",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-			"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
-			"dev": true,
-			"bin": {
-				"babylon": "bin/babylon.js"
-			},
-			"engines": {
-				"node": ">=6.0.0"
-			}
 		},
 		"node_modules/balanced-match": {
 			"version": "1.0.2",
@@ -1179,20 +809,6 @@
 				}
 			]
 		},
-		"node_modules/chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"dependencies": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -1255,31 +871,10 @@
 				"node": ">=6"
 			}
 		},
-		"node_modules/color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"dependencies": {
-				"color-name": "1.1.3"
-			}
-		},
-		"node_modules/color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
 		"node_modules/colorette": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
 			"integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-			"dev": true
-		},
-		"node_modules/command-exists": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
 			"dev": true
 		},
 		"node_modules/commander": {
@@ -1390,15 +985,6 @@
 			"dev": true,
 			"engines": {
 				"node": ">= 0.6"
-			}
-		},
-		"node_modules/convert-source-map": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-			"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-			"dev": true,
-			"dependencies": {
-				"safe-buffer": "~5.1.1"
 			}
 		},
 		"node_modules/cookie": {
@@ -1749,15 +1335,6 @@
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
 			"dev": true
-		},
-		"node_modules/escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.8.0"
-			}
 		},
 		"node_modules/eslint-scope": {
 			"version": "5.1.1",
@@ -2113,15 +1690,6 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"node_modules/gensync": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-			"dev": true,
-			"engines": {
-				"node": ">=6.9.0"
-			}
-		},
 		"node_modules/get-intrinsic": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
@@ -2186,15 +1754,6 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true
 		},
-		"node_modules/globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -2217,15 +1776,6 @@
 			},
 			"engines": {
 				"node": ">= 0.4.0"
-			}
-		},
-		"node_modules/has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
 			}
 		},
 		"node_modules/has-symbols": {
@@ -2658,24 +2208,6 @@
 				"url": "https://github.com/chalk/supports-color?sponsor=1"
 			}
 		},
-		"node_modules/js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
-		"node_modules/jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true,
-			"bin": {
-				"jsesc": "bin/jsesc"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -2749,15 +2281,6 @@
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
 			"dev": true
-		},
-		"node_modules/long": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
-			"dev": true,
-			"engines": {
-				"node": ">=0.6"
-			}
 		},
 		"node_modules/lower-case": {
 			"version": "2.0.2",
@@ -2894,12 +2417,6 @@
 			"engines": {
 				"node": "*"
 			}
-		},
-		"node_modules/minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
 		},
 		"node_modules/monaco-editor": {
 			"version": "0.34.0",
@@ -3996,18 +3513,6 @@
 				"webpack": "^5.0.0"
 			}
 		},
-		"node_modules/supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"dependencies": {
-				"has-flag": "^3.0.0"
-			},
-			"engines": {
-				"node": ">=4"
-			}
-		},
 		"node_modules/supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -4099,15 +3604,6 @@
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
 			"dev": true
-		},
-		"node_modules/to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
-			"dev": true,
-			"engines": {
-				"node": ">=4"
-			}
 		},
 		"node_modules/to-regex-range": {
 			"version": "5.0.1",
@@ -4339,58 +3835,6 @@
 				"node": ">= 0.8"
 			}
 		},
-		"node_modules/wasm-dce": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wasm-dce/-/wasm-dce-1.0.2.tgz",
-			"integrity": "sha512-Fq1+nu43ybsjSnBquLrW/cULmKs61qbv9k8ep13QUe0nABBezMoNAA+j6QY66MW0/eoDVDp1rjXDqQ2VKyS/Xg==",
-			"dev": true,
-			"dependencies": {
-				"@babel/core": "^7.0.0-beta.39",
-				"@babel/traverse": "^7.0.0-beta.39",
-				"@babel/types": "^7.0.0-beta.39",
-				"babylon": "^7.0.0-beta.39",
-				"webassembly-interpreter": "0.0.30"
-			}
-		},
-		"node_modules/wasm-loader": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/wasm-loader/-/wasm-loader-1.3.0.tgz",
-			"integrity": "sha512-R4s75XH+o8qM+WaRrAU9S2rbAMDzob18/S3V8R9ZoFpZkPWLAohWWlzWAp1ybeTkOuuku/X1zJtxiV0pBYxZww==",
-			"dev": true,
-			"dependencies": {
-				"loader-utils": "^1.1.0",
-				"wasm-dce": "^1.0.0"
-			},
-			"peerDependencies": {
-				"wasm-dce": "1.x"
-			}
-		},
-		"node_modules/wasm-loader/node_modules/json5": {
-			"version": "1.0.1",
-			"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-			"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-			"dev": true,
-			"dependencies": {
-				"minimist": "^1.2.0"
-			},
-			"bin": {
-				"json5": "lib/cli.js"
-			}
-		},
-		"node_modules/wasm-loader/node_modules/loader-utils": {
-			"version": "1.4.0",
-			"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-			"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-			"dev": true,
-			"dependencies": {
-				"big.js": "^5.2.2",
-				"emojis-list": "^3.0.0",
-				"json5": "^1.0.1"
-			},
-			"engines": {
-				"node": ">=4.0.0"
-			}
-		},
 		"node_modules/watchpack": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -4411,34 +3855,6 @@
 			"dev": true,
 			"dependencies": {
 				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"node_modules/webassembly-floating-point-hex-parser": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/webassembly-floating-point-hex-parser/-/webassembly-floating-point-hex-parser-0.1.2.tgz",
-			"integrity": "sha512-TUf1H++8U10+stJbFydnvrpG5Sznz5Rilez/oZlV5zI0C/e4cSxd8rALAJ8VpTvjVWxLmL3SVSJUK6Ap9AoiNg==",
-			"dev": true,
-			"engines": {
-				"node": "*"
-			}
-		},
-		"node_modules/webassembly-interpreter": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/webassembly-interpreter/-/webassembly-interpreter-0.0.30.tgz",
-			"integrity": "sha512-+Jdy2piEvz9T5j751mOE8+rBO12p+nNW6Fg4kJZ+zP1oUfsm+151sbAbM8AFxWTURmWCGP+r8Lxwfv3pzN1bCQ==",
-			"dev": true,
-			"dependencies": {
-				"@babel/code-frame": "^7.0.0-beta.36",
-				"long": "^3.2.0",
-				"webassembly-floating-point-hex-parser": "0.1.2"
-			},
-			"bin": {
-				"wasm": "lib/bin/repl.js",
-				"wasm2wast": "lib/bin/wasm2wast.js",
-				"wasmast": "lib/bin/wasmast.js",
-				"wasmdump": "lib/bin/wasmdump.js",
-				"wasmrun": "lib/bin/wasmrun.js",
-				"wastast": "lib/bin/wastast.js"
 			}
 		},
 		"node_modules/webpack": {
@@ -4838,259 +4254,6 @@
 		}
 	},
 	"dependencies": {
-		"@ampproject/remapping": {
-			"version": "2.2.0",
-			"resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.0.tgz",
-			"integrity": "sha512-qRmjj8nj9qmLTQXXmaR1cck3UXSRMPrbsLJAasZpF+t3riI71BXed5ebIOYwQntykeZuhjsdweEc9BxH5Jc26w==",
-			"dev": true,
-			"requires": {
-				"@jridgewell/gen-mapping": "^0.1.0",
-				"@jridgewell/trace-mapping": "^0.3.9"
-			},
-			"dependencies": {
-				"@jridgewell/gen-mapping": {
-					"version": "0.1.1",
-					"resolved": "https://registry.npmjs.org/@jridgewell/gen-mapping/-/gen-mapping-0.1.1.tgz",
-					"integrity": "sha512-sQXCasFk+U8lWYEe66WxRDOE9PjVz4vSM51fTu3Hw+ClTpUSQb718772vH3pyS5pShp6lvQM7SxgIDXXXmOX7w==",
-					"dev": true,
-					"requires": {
-						"@jridgewell/set-array": "^1.0.0",
-						"@jridgewell/sourcemap-codec": "^1.4.10"
-					}
-				}
-			}
-		},
-		"@babel/code-frame": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.18.6.tgz",
-			"integrity": "sha512-TDCmlK5eOvH+eH7cdAFlNXeVJqWIQ7gW9tY1GJIpUtFb6CmjVyq2VM3u71bOyR8CRihcCgMUYoDNyLXao3+70Q==",
-			"dev": true,
-			"requires": {
-				"@babel/highlight": "^7.18.6"
-			}
-		},
-		"@babel/compat-data": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/compat-data/-/compat-data-7.18.13.tgz",
-			"integrity": "sha512-5yUzC5LqyTFp2HLmDoxGQelcdYgSpP9xsnMWBphAscOdFrHSAVbLNzWiy32sVNDqJRDiJK6klfDnAgu6PAGSHw==",
-			"dev": true
-		},
-		"@babel/core": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/core/-/core-7.18.13.tgz",
-			"integrity": "sha512-ZisbOvRRusFktksHSG6pjj1CSvkPkcZq/KHD45LAkVP/oiHJkNBZWfpvlLmX8OtHDG8IuzsFlVRWo08w7Qxn0A==",
-			"dev": true,
-			"requires": {
-				"@ampproject/remapping": "^2.1.0",
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.13",
-				"@babel/helper-compilation-targets": "^7.18.9",
-				"@babel/helper-module-transforms": "^7.18.9",
-				"@babel/helpers": "^7.18.9",
-				"@babel/parser": "^7.18.13",
-				"@babel/template": "^7.18.10",
-				"@babel/traverse": "^7.18.13",
-				"@babel/types": "^7.18.13",
-				"convert-source-map": "^1.7.0",
-				"debug": "^4.1.0",
-				"gensync": "^1.0.0-beta.2",
-				"json5": "^2.2.1",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
-		"@babel/generator": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.18.13.tgz",
-			"integrity": "sha512-CkPg8ySSPuHTYPJYo7IRALdqyjM9HCbt/3uOBEFbzyGVP6Mn8bwFPB0jX6982JVNBlYzM1nnPkfjuXSOPtQeEQ==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.18.13",
-				"@jridgewell/gen-mapping": "^0.3.2",
-				"jsesc": "^2.5.1"
-			}
-		},
-		"@babel/helper-compilation-targets": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.18.9.tgz",
-			"integrity": "sha512-tzLCyVmqUiFlcFoAPLA/gL9TeYrF61VLNtb+hvkuVaB5SUjW7jcfrglBIX1vUIoT7CLP3bBlIMeyEsIl2eFQNg==",
-			"dev": true,
-			"requires": {
-				"@babel/compat-data": "^7.18.8",
-				"@babel/helper-validator-option": "^7.18.6",
-				"browserslist": "^4.20.2",
-				"semver": "^6.3.0"
-			},
-			"dependencies": {
-				"semver": {
-					"version": "6.3.0",
-					"resolved": "https://registry.npmjs.org/semver/-/semver-6.3.0.tgz",
-					"integrity": "sha512-b39TBaTSfV6yBrapU89p5fKekE2m/NwnDocOVruQFS1/veMgdzuPcnOM34M6CwxW8jH/lxEa5rBoDeUwu5HHTw==",
-					"dev": true
-				}
-			}
-		},
-		"@babel/helper-environment-visitor": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-environment-visitor/-/helper-environment-visitor-7.18.9.tgz",
-			"integrity": "sha512-3r/aACDJ3fhQ/EVgFy0hpj8oHyHpQc+LPtJoY9SzTThAsStm4Ptegq92vqKoE3vD706ZVFWITnMnxucw+S9Ipg==",
-			"dev": true
-		},
-		"@babel/helper-function-name": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-function-name/-/helper-function-name-7.18.9.tgz",
-			"integrity": "sha512-fJgWlZt7nxGksJS9a0XdSaI4XvpExnNIgRP+rVefWh5U7BL8pPuir6SJUmFKRfjWQ51OtWSzwOxhaH/EBWWc0A==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.18.6",
-				"@babel/types": "^7.18.9"
-			}
-		},
-		"@babel/helper-hoist-variables": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-hoist-variables/-/helper-hoist-variables-7.18.6.tgz",
-			"integrity": "sha512-UlJQPkFqFULIcyW5sbzgbkxn2FKRgwWiRexcuaR8RNJRy8+LLveqPjwZV/bwrLZCN0eUHD/x8D0heK1ozuoo6Q==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.18.6"
-			}
-		},
-		"@babel/helper-module-imports": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-imports/-/helper-module-imports-7.18.6.tgz",
-			"integrity": "sha512-0NFvs3VkuSYbFi1x2Vd6tKrywq+z/cLeYC/RJNFrIX/30Bf5aiGYbtvGXolEktzJH8o5E5KJ3tT+nkxuuZFVlA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.18.6"
-			}
-		},
-		"@babel/helper-module-transforms": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helper-module-transforms/-/helper-module-transforms-7.18.9.tgz",
-			"integrity": "sha512-KYNqY0ICwfv19b31XzvmI/mfcylOzbLtowkw+mfvGPAQ3kfCnMLYbED3YecL5tPd8nAYFQFAd6JHp2LxZk/J1g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-module-imports": "^7.18.6",
-				"@babel/helper-simple-access": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
-			}
-		},
-		"@babel/helper-simple-access": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-simple-access/-/helper-simple-access-7.18.6.tgz",
-			"integrity": "sha512-iNpIgTgyAvDQpDj76POqg+YEt8fPxx3yaNBg3S30dxNKm2SWfYhD0TGrK/Eu9wHpUW63VQU894TsTg+GLbUa1g==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.18.6"
-			}
-		},
-		"@babel/helper-split-export-declaration": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-split-export-declaration/-/helper-split-export-declaration-7.18.6.tgz",
-			"integrity": "sha512-bde1etTx6ZyTmobl9LLMMQsaizFVZrquTEHOqKeQESMKo4PlObf+8+JA25ZsIpZhT/WEd39+vOdLXAFG/nELpA==",
-			"dev": true,
-			"requires": {
-				"@babel/types": "^7.18.6"
-			}
-		},
-		"@babel/helper-string-parser": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/helper-string-parser/-/helper-string-parser-7.18.10.tgz",
-			"integrity": "sha512-XtIfWmeNY3i4t7t4D2t02q50HvqHybPqW2ki1kosnvWCwuCMeo81Jf0gwr85jy/neUdg5XDdeFE/80DXiO+njw==",
-			"dev": true
-		},
-		"@babel/helper-validator-identifier": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.18.6.tgz",
-			"integrity": "sha512-MmetCkz9ej86nJQV+sFCxoGGrUbU3q02kgLciwkrt9QqEB7cP39oKEY0PakknEO0Gu20SskMRi+AYZ3b1TpN9g==",
-			"dev": true
-		},
-		"@babel/helper-validator-option": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/helper-validator-option/-/helper-validator-option-7.18.6.tgz",
-			"integrity": "sha512-XO7gESt5ouv/LRJdrVjkShckw6STTaB7l9BrpBaAHDeF5YZT+01PCwmR0SJHnkW6i8OwW/EVWRShfi4j2x+KQw==",
-			"dev": true
-		},
-		"@babel/helpers": {
-			"version": "7.18.9",
-			"resolved": "https://registry.npmjs.org/@babel/helpers/-/helpers-7.18.9.tgz",
-			"integrity": "sha512-Jf5a+rbrLoR4eNdUmnFu8cN5eNJT6qdTdOg5IHIzq87WwyRw9PwguLFOWYgktN/60IP4fgDUawJvs7PjQIzELQ==",
-			"dev": true,
-			"requires": {
-				"@babel/template": "^7.18.6",
-				"@babel/traverse": "^7.18.9",
-				"@babel/types": "^7.18.9"
-			}
-		},
-		"@babel/highlight": {
-			"version": "7.18.6",
-			"resolved": "https://registry.npmjs.org/@babel/highlight/-/highlight-7.18.6.tgz",
-			"integrity": "sha512-u7stbOuYjaPezCuLj29hNW1v64M2Md2qupEKP1fHc7WdOA3DgLh37suiSrZYY7haUB7iBeQZ9P1uiRF359do3g==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"chalk": "^2.0.0",
-				"js-tokens": "^4.0.0"
-			}
-		},
-		"@babel/parser": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.18.13.tgz",
-			"integrity": "sha512-dgXcIfMuQ0kgzLB2b9tRZs7TTFFaGM2AbtA4fJgUUYukzGH4jwsS7hzQHEGs67jdehpm22vkgKwvbU+aEflgwg==",
-			"dev": true
-		},
-		"@babel/template": {
-			"version": "7.18.10",
-			"resolved": "https://registry.npmjs.org/@babel/template/-/template-7.18.10.tgz",
-			"integrity": "sha512-TI+rCtooWHr3QJ27kJxfjutghu44DLnasDMwpDqCXVTal9RLp3RSYNh4NdBrRP2cQAoG9A8juOQl6P6oZG4JxA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/parser": "^7.18.10",
-				"@babel/types": "^7.18.10"
-			}
-		},
-		"@babel/traverse": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.18.13.tgz",
-			"integrity": "sha512-N6kt9X1jRMLPxxxPYWi7tgvJRH/rtoU+dbKAPDM44RFHiMH8igdsaSBgFeskhSl/kLWLDUvIh1RXCrTmg0/zvA==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.18.6",
-				"@babel/generator": "^7.18.13",
-				"@babel/helper-environment-visitor": "^7.18.9",
-				"@babel/helper-function-name": "^7.18.9",
-				"@babel/helper-hoist-variables": "^7.18.6",
-				"@babel/helper-split-export-declaration": "^7.18.6",
-				"@babel/parser": "^7.18.13",
-				"@babel/types": "^7.18.13",
-				"debug": "^4.1.0",
-				"globals": "^11.1.0"
-			}
-		},
-		"@babel/types": {
-			"version": "7.18.13",
-			"resolved": "https://registry.npmjs.org/@babel/types/-/types-7.18.13.tgz",
-			"integrity": "sha512-ePqfTihzW0W6XAU+aMw2ykilisStJfDnsejDCXRchCcMJ4O0+8DhPXf2YUbZ6wjBlsEmZwLK/sPweWtu8hcJYQ==",
-			"dev": true,
-			"requires": {
-				"@babel/helper-string-parser": "^7.18.10",
-				"@babel/helper-validator-identifier": "^7.18.6",
-				"to-fast-properties": "^2.0.0"
-			}
-		},
 		"@discoveryjs/json-ext": {
 			"version": "0.5.7",
 			"resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.5.7.tgz",
@@ -5331,18 +4494,6 @@
 			"dev": true,
 			"requires": {
 				"@types/node": "*"
-			}
-		},
-		"@wasm-tool/wasm-pack-plugin": {
-			"version": "1.5.0",
-			"resolved": "https://registry.npmjs.org/@wasm-tool/wasm-pack-plugin/-/wasm-pack-plugin-1.5.0.tgz",
-			"integrity": "sha512-qsGJ953zrXZdXW58cfYOh2nBXp0SYBsFhkxqh9p4JK8cXllEzHeRXoVO+qtgEB31+s1tsL8eda3Uy97W/7yOAg==",
-			"dev": true,
-			"requires": {
-				"chalk": "^2.4.1",
-				"command-exists": "^1.2.7",
-				"watchpack": "^2.1.1",
-				"which": "^2.0.2"
 			}
 		},
 		"@webassemblyjs/ast": {
@@ -5609,15 +4760,6 @@
 			"integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
 			"dev": true
 		},
-		"ansi-styles": {
-			"version": "3.2.1",
-			"resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
-			"integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
-			"dev": true,
-			"requires": {
-				"color-convert": "^1.9.0"
-			}
-		},
 		"anymatch": {
 			"version": "3.1.2",
 			"resolved": "https://registry.npmjs.org/anymatch/-/anymatch-3.1.2.tgz",
@@ -5632,12 +4774,6 @@
 			"version": "2.1.2",
 			"resolved": "https://registry.npmjs.org/array-flatten/-/array-flatten-2.1.2.tgz",
 			"integrity": "sha512-hNfzcOV8W4NdualtqBFPyVO+54DSJuZGY9qT4pRroB6S9e3iiido2ISIC5h9R2sPJ8H3FHCIiEnsv1lPXO3KtQ==",
-			"dev": true
-		},
-		"babylon": {
-			"version": "7.0.0-beta.47",
-			"resolved": "https://registry.npmjs.org/babylon/-/babylon-7.0.0-beta.47.tgz",
-			"integrity": "sha512-+rq2cr4GDhtToEzKFD6KZZMDBXhjFAr9JjPw9pAppZACeEWqNM294j+NdBzkSHYXwzzBmVjZ3nEVJlOhbR2gOQ==",
 			"dev": true
 		},
 		"balanced-match": {
@@ -5794,17 +4930,6 @@
 			"integrity": "sha512-fKDH0F1KOJvR+mWSOvhj8lVRr/Q/mc5u5nabU2vi1/sgvlSqEsE8dOq0Hy/BqVbDkCYQPRRHB1WRjW6PGB/7PA==",
 			"dev": true
 		},
-		"chalk": {
-			"version": "2.4.2",
-			"resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
-			"integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
-			"dev": true,
-			"requires": {
-				"ansi-styles": "^3.2.1",
-				"escape-string-regexp": "^1.0.5",
-				"supports-color": "^5.3.0"
-			}
-		},
 		"chokidar": {
 			"version": "3.5.3",
 			"resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -5847,31 +4972,10 @@
 				"shallow-clone": "^3.0.0"
 			}
 		},
-		"color-convert": {
-			"version": "1.9.3",
-			"resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
-			"integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
-			"dev": true,
-			"requires": {
-				"color-name": "1.1.3"
-			}
-		},
-		"color-name": {
-			"version": "1.1.3",
-			"resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
-			"integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
-			"dev": true
-		},
 		"colorette": {
 			"version": "2.0.19",
 			"resolved": "https://registry.npmjs.org/colorette/-/colorette-2.0.19.tgz",
 			"integrity": "sha512-3tlv/dIP7FWvj3BsbHrGLJ6l/oKh1O3TcgBqMn+yyCagOxc23fyzDS6HypQbgxWbkpDnf52p1LuR4eWDQ/K9WQ==",
-			"dev": true
-		},
-		"command-exists": {
-			"version": "1.2.9",
-			"resolved": "https://registry.npmjs.org/command-exists/-/command-exists-1.2.9.tgz",
-			"integrity": "sha512-LTQ/SGc+s0Xc0Fu5WaKnR0YiygZkm9eKFvyS+fRsU7/ZWFF8ykFM6Pc9aCVf1+xasOOZpO3BAVgVrKvsqKHV7w==",
 			"dev": true
 		},
 		"commander": {
@@ -5955,15 +5059,6 @@
 			"resolved": "https://registry.npmjs.org/content-type/-/content-type-1.0.4.tgz",
 			"integrity": "sha512-hIP3EEPs8tB9AT1L+NUqtwOAps4mk2Zob89MWXMHjHWg9milF/j4osnnQLXBCBFBk/tvIG/tUc9mOUJiPBhPXA==",
 			"dev": true
-		},
-		"convert-source-map": {
-			"version": "1.8.0",
-			"resolved": "https://registry.npmjs.org/convert-source-map/-/convert-source-map-1.8.0.tgz",
-			"integrity": "sha512-+OQdjP49zViI/6i7nIJpA8rAl4sV/JdPfU9nZs3VqOwGIgizICvuN2ru6fMd+4llL0tar18UYJXfZ/TWtmhUjA==",
-			"dev": true,
-			"requires": {
-				"safe-buffer": "~5.1.1"
-			}
 		},
 		"cookie": {
 			"version": "0.5.0",
@@ -6218,12 +5313,6 @@
 			"version": "1.0.3",
 			"resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
 			"integrity": "sha512-NiSupZ4OeuGwr68lGIeym/ksIZMJodUGOSCZ/FSnTxcrekbvqrgdUxlJOMpijaKZVjAJrWrGs/6Jy8OMuyj9ow==",
-			"dev": true
-		},
-		"escape-string-regexp": {
-			"version": "1.0.5",
-			"resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-			"integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
 			"dev": true
 		},
 		"eslint-scope": {
@@ -6493,12 +5582,6 @@
 			"integrity": "sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==",
 			"dev": true
 		},
-		"gensync": {
-			"version": "1.0.0-beta.2",
-			"resolved": "https://registry.npmjs.org/gensync/-/gensync-1.0.0-beta.2.tgz",
-			"integrity": "sha512-3hN7NaskYvMDLQY55gnW3NQ+mesEAepTqlg+VEbj7zzqEMBVNhzcGYYeqFo/TlYz6eQiFcp1HcsCZO+nGgS8zg==",
-			"dev": true
-		},
 		"get-intrinsic": {
 			"version": "1.1.2",
 			"resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.1.2.tgz",
@@ -6545,12 +5628,6 @@
 			"integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
 			"dev": true
 		},
-		"globals": {
-			"version": "11.12.0",
-			"resolved": "https://registry.npmjs.org/globals/-/globals-11.12.0.tgz",
-			"integrity": "sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==",
-			"dev": true
-		},
 		"graceful-fs": {
 			"version": "4.2.10",
 			"resolved": "https://registry.npmjs.org/graceful-fs/-/graceful-fs-4.2.10.tgz",
@@ -6571,12 +5648,6 @@
 			"requires": {
 				"function-bind": "^1.1.1"
 			}
-		},
-		"has-flag": {
-			"version": "3.0.0",
-			"resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
-			"integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
-			"dev": true
 		},
 		"has-symbols": {
 			"version": "1.0.3",
@@ -6878,18 +5949,6 @@
 				}
 			}
 		},
-		"js-tokens": {
-			"version": "4.0.0",
-			"resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-4.0.0.tgz",
-			"integrity": "sha512-RdJUflcE3cUzKiMqQgsCu06FPu9UdIJO0beYbPhHN4k6apgJtifcoCtT9bcxOpYBtpD2kCM6Sbzg4CausW/PKQ==",
-			"dev": true
-		},
-		"jsesc": {
-			"version": "2.5.2",
-			"resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
-			"integrity": "sha512-OYu7XEzjkCQ3C5Ps3QIZsQfNpqoJyZZA99wd9aWd05NCtC5pWOkShK2mkL6HXQR6/Cy2lbNdPlZBpuQHXE63gA==",
-			"dev": true
-		},
 		"json-parse-even-better-errors": {
 			"version": "2.3.1",
 			"resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
@@ -6944,12 +6003,6 @@
 			"version": "4.17.21",
 			"resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
 			"integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
-			"dev": true
-		},
-		"long": {
-			"version": "3.2.0",
-			"resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
-			"integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg==",
 			"dev": true
 		},
 		"lower-case": {
@@ -7054,12 +6107,6 @@
 			"requires": {
 				"brace-expansion": "^1.1.7"
 			}
-		},
-		"minimist": {
-			"version": "1.2.6",
-			"resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.6.tgz",
-			"integrity": "sha512-Jsjnk4bw3YJqYzbdyBiNsPWHPfO++UGG749Cxs6peCu5Xg4nrena6OVxOYxrQTqww0Jmwt+Ref8rggumkTLz9Q==",
-			"dev": true
 		},
 		"monaco-editor": {
 			"version": "0.34.0",
@@ -7912,15 +6959,6 @@
 			"dev": true,
 			"requires": {}
 		},
-		"supports-color": {
-			"version": "5.5.0",
-			"resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
-			"integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
-			"dev": true,
-			"requires": {
-				"has-flag": "^3.0.0"
-			}
-		},
 		"supports-preserve-symlinks-flag": {
 			"version": "1.0.0",
 			"resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
@@ -7976,12 +7014,6 @@
 			"version": "1.1.0",
 			"resolved": "https://registry.npmjs.org/thunky/-/thunky-1.1.0.tgz",
 			"integrity": "sha512-eHY7nBftgThBqOyHGVN+l8gF0BucP09fMo0oO/Lb0w1OF80dJv+lDVpXG60WMQvkcxAkNybKsrEIE3ZtKGmPrA==",
-			"dev": true
-		},
-		"to-fast-properties": {
-			"version": "2.0.0",
-			"resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-2.0.0.tgz",
-			"integrity": "sha512-/OaKK0xYrs3DmxRYqL/yDc+FxFUVYhDlXMhRmv3z915w2HF1tnN1omB354j8VUGO/hbRzyD6Y3sA7v7GS/ceog==",
 			"dev": true
 		},
 		"to-regex-range": {
@@ -8144,51 +7176,6 @@
 			"integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
 			"dev": true
 		},
-		"wasm-dce": {
-			"version": "1.0.2",
-			"resolved": "https://registry.npmjs.org/wasm-dce/-/wasm-dce-1.0.2.tgz",
-			"integrity": "sha512-Fq1+nu43ybsjSnBquLrW/cULmKs61qbv9k8ep13QUe0nABBezMoNAA+j6QY66MW0/eoDVDp1rjXDqQ2VKyS/Xg==",
-			"dev": true,
-			"requires": {
-				"@babel/core": "^7.0.0-beta.39",
-				"@babel/traverse": "^7.0.0-beta.39",
-				"@babel/types": "^7.0.0-beta.39",
-				"babylon": "^7.0.0-beta.39",
-				"webassembly-interpreter": "0.0.30"
-			}
-		},
-		"wasm-loader": {
-			"version": "1.3.0",
-			"resolved": "https://registry.npmjs.org/wasm-loader/-/wasm-loader-1.3.0.tgz",
-			"integrity": "sha512-R4s75XH+o8qM+WaRrAU9S2rbAMDzob18/S3V8R9ZoFpZkPWLAohWWlzWAp1ybeTkOuuku/X1zJtxiV0pBYxZww==",
-			"dev": true,
-			"requires": {
-				"loader-utils": "^1.1.0",
-				"wasm-dce": "^1.0.0"
-			},
-			"dependencies": {
-				"json5": {
-					"version": "1.0.1",
-					"resolved": "https://registry.npmjs.org/json5/-/json5-1.0.1.tgz",
-					"integrity": "sha512-aKS4WQjPenRxiQsC93MNfjx+nbF4PAdYzmd/1JIj8HYzqfbu86beTuNgXDzPknWk0n0uARlyewZo4s++ES36Ow==",
-					"dev": true,
-					"requires": {
-						"minimist": "^1.2.0"
-					}
-				},
-				"loader-utils": {
-					"version": "1.4.0",
-					"resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.4.0.tgz",
-					"integrity": "sha512-qH0WSMBtn/oHuwjy/NucEgbx5dbxxnxup9s4PVXJUDHZBQY+s0NWA9rJf53RBnQZxfch7euUui7hpoAPvALZdA==",
-					"dev": true,
-					"requires": {
-						"big.js": "^5.2.2",
-						"emojis-list": "^3.0.0",
-						"json5": "^1.0.1"
-					}
-				}
-			}
-		},
 		"watchpack": {
 			"version": "2.4.0",
 			"resolved": "https://registry.npmjs.org/watchpack/-/watchpack-2.4.0.tgz",
@@ -8206,23 +7193,6 @@
 			"dev": true,
 			"requires": {
 				"minimalistic-assert": "^1.0.0"
-			}
-		},
-		"webassembly-floating-point-hex-parser": {
-			"version": "0.1.2",
-			"resolved": "https://registry.npmjs.org/webassembly-floating-point-hex-parser/-/webassembly-floating-point-hex-parser-0.1.2.tgz",
-			"integrity": "sha512-TUf1H++8U10+stJbFydnvrpG5Sznz5Rilez/oZlV5zI0C/e4cSxd8rALAJ8VpTvjVWxLmL3SVSJUK6Ap9AoiNg==",
-			"dev": true
-		},
-		"webassembly-interpreter": {
-			"version": "0.0.30",
-			"resolved": "https://registry.npmjs.org/webassembly-interpreter/-/webassembly-interpreter-0.0.30.tgz",
-			"integrity": "sha512-+Jdy2piEvz9T5j751mOE8+rBO12p+nNW6Fg4kJZ+zP1oUfsm+151sbAbM8AFxWTURmWCGP+r8Lxwfv3pzN1bCQ==",
-			"dev": true,
-			"requires": {
-				"@babel/code-frame": "^7.0.0-beta.36",
-				"long": "^3.2.0",
-				"webassembly-floating-point-hex-parser": "0.1.2"
 			}
 		},
 		"webpack": {

--- a/packages/json-encoder-web/package.json
+++ b/packages/json-encoder-web/package.json
@@ -1,11 +1,11 @@
 {
 	"scripts": {
-		"build": "webpack --mode production",
-		"serve": "webpack serve --progress"
+		"build:wasm": "node build-wasm.js",
+		"build": "npm run build:wasm && webpack --mode production",
+		"serve": "npm run build:wasm && webpack serve --progress"
 	},
 	"devDependencies": {
 		"@types/notie": "^4.3.0",
-		"@wasm-tool/wasm-pack-plugin": "1.5.0",
 		"css-loader": "^6.7.1",
 		"file-loader": "^6.2.0",
 		"html-webpack-plugin": "^5.3.2",
@@ -14,7 +14,6 @@
 		"style-loader": "^3.3.1",
 		"ts-loader": "^9.3.1",
 		"typescript": "^4.8.2",
-		"wasm-loader": "^1.3.0",
 		"webpack": "^5.49.0",
 		"webpack-cli": "^4.7.2",
 		"webpack-dev-server": "^4.10.1"

--- a/packages/json-encoder-web/webpack.config.js
+++ b/packages/json-encoder-web/webpack.config.js
@@ -1,7 +1,6 @@
 const webpack = require('webpack');
 const path = require('path');
 const HtmlWebpackPlugin = require('html-webpack-plugin');
-const WasmPackPlugin = require("@wasm-tool/wasm-pack-plugin");
 const MonacoWebpackPlugin = require('monaco-editor-webpack-plugin');
 
 module.exports = {
@@ -17,9 +16,6 @@ module.exports = {
 	plugins: [
 		new HtmlWebpackPlugin({
 			template: 'index.html'
-		}),
-		new WasmPackPlugin({
-			crateDirectory: path.resolve(__dirname, '.')
 		}),
 		new MonacoWebpackPlugin({
 			// We don't want to pollute our distribution with support for many
@@ -56,6 +52,6 @@ module.exports = {
 		]
 	},
 	resolve: {
-		extensions: ['', '.js', '.jsx', '.css', '.ts']
+		extensions: ['', '.js', '.jsx', '.css', '.ts', '.wasm']
 	}
 };


### PR DESCRIPTION
## Summary

This PR migrates the json-encoder-web build system from wasm-pack to using wasm-bindgen directly, addressing maintenance concerns with wasm-pack and giving us more control over the build process.

## Changes

- **Build System Migration**:
  - Created `build-wasm.js` script that directly calls `cargo build` and `wasm-bindgen`
  - Removed dependency on `@wasm-tool/wasm-pack-plugin` and `wasm-loader`
  - Updated webpack config to use Webpack 5's native `asyncWebAssembly` support

- **CI/CD Updates**:
  - Updated GitHub Actions workflow to install Rust toolchain with `wasm32-unknown-unknown` target
  - Added `wasm-bindgen-cli` installation step (v0.2.100)

- **Import Path Update**:
  - Changed import from `'./pkg'` to `'./pkg/json_encoder_web'` to match wasm-bindgen output

- **Housekeeping**:
  - Added `.gitignore` for generated files (`pkg/`, `dist/`, `target/`)
  - Cleaned up package.json dependencies

## Benefits

1. **More Control**: Direct control over compilation flags and build process
2. **Better Error Messages**: Direct access to cargo and wasm-bindgen output
3. **No External Dependencies**: No need to install wasm-pack globally
4. **Modern Webpack Integration**: Uses Webpack 5's native WebAssembly support

## Testing

- ✅ Build process works correctly (`npm run build`)
- ✅ Development server works (`npm run serve`)
- ✅ WASM functionality verified in browser
- ✅ CI/CD workflow updated

## Migration Notes

Developers will need to install:
```bash
rustup target add wasm32-unknown-unknown
cargo install wasm-bindgen-cli --version "0.2.100"
```

🤖 Generated with [Claude Code](https://claude.ai/code)